### PR TITLE
feat: add global hotkey and number key shortcuts for popover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tmp/
+.worktrees/
 target/
 build/
 dist/

--- a/ccfocus-app/ccfocus-app/CcfocusApp.swift
+++ b/ccfocus-app/ccfocus-app/CcfocusApp.swift
@@ -2,10 +2,6 @@ import AppKit
 import ServiceManagement
 import SwiftUI
 
-final class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-}
-
 @main
 struct CcfocusApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -16,15 +12,19 @@ struct CcfocusApp: App {
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
     private let state = AppState()
+    private var stateMachine = PopoverStateMachine()
+    private let hotkeyController = HotkeyController()
+    private let settingsWindowController = SettingsWindowController()
+    private var keyObservers: [NSObjectProtocol] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         registerLoginItemIfNeeded()
         state.bootstrap()
-        state.onOpenPopover = { [weak self] in self?.showPopover() }
+        state.onOpenPopover = { [weak self] in self?.showPopoverUnfocused() }
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
@@ -35,24 +35,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         popover = NSPopover()
         popover.behavior = .transient
+        popover.delegate = self
         let vc = NSViewController()
-        vc.view = FirstMouseHostingView(
-            rootView: MenuBarView(state: state) { [weak self] in self?.popover.performClose(nil) }
+        let menuView = MenuBarView(
+            state: state,
+            onDismiss: { [weak self] in self?.popover.performClose(nil) },
+            onOpenSettings: { [weak self] in self?.settingsWindowController.show() }
         )
+        let hostingView = KeyHandlingHostingView(rootView: menuView)
+        hostingView.onKeyDown = { [weak self] event in
+            self?.handleKeyDown(event) ?? false
+        }
+        vc.view = hostingView
         popover.contentViewController = vc
+
+        hotkeyController.onToggleFocus = { [weak self] in self?.handleHotkey() }
+        hotkeyController.start()
+
+        observeKeyWindowNotifications()
     }
 
     @objc private func togglePopover() {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            showPopover()
+            showPopoverUnfocused()
         }
     }
 
-    private func showPopover() {
+    private func handleHotkey() {
+        let action = stateMachine.handleHotkey()
+        switch action {
+        case .showAndFocus:
+            showPopoverUnfocused()
+            focusPopover()
+        case .focus:
+            focusPopover()
+        case .close:
+            popover.performClose(nil)
+        }
+    }
+
+    private func showPopoverUnfocused() {
         guard let button = statusItem.button else { return }
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        if !popover.isShown {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            stateMachine.markOpenedUnfocused()
+            observeKeyWindowNotifications()
+        }
+    }
+
+    private func focusPopover() {
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = popover.contentViewController?.view.window,
+           let hostingView = popover.contentViewController?.view {
+            window.makeKeyAndOrderFront(nil)
+            window.makeFirstResponder(hostingView)
+        }
+    }
+
+    private func handleKeyDown(_ event: NSEvent) -> Bool {
+        guard stateMachine.state == .openFocused else { return false }
+        if event.keyCode == 53 {
+            popover.performClose(nil)
+            return true
+        }
+        guard let chars = event.charactersIgnoringModifiers, let c = chars.first,
+              let index = KeyActionResolver.numberIndex(forCharacter: c) else {
+            return false
+        }
+        let entries = state.registry.sortedByLastEventDesc().filter { $0.status != .deceased }
+        guard let entry = KeyActionResolver.select(from: entries, numberIndex: index) else { return false }
+        state.clearMessage(entry.sessionId)
+        state.clearDoneNotified(entry.sessionId)
+        if let id = state.effectiveTerminalId(for: entry) {
+            GhosttyFocus.focus(terminalId: id)
+            popover.performClose(nil)
+        }
+        return true
+    }
+
+    private func observeKeyWindowNotifications() {
+        keyObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        keyObservers.removeAll()
+        guard let window = popover.contentViewController?.view.window else { return }
+        let center = NotificationCenter.default
+        let becameKey = center.addObserver(forName: NSWindow.didBecomeKeyNotification, object: window, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.stateMachine.markBecameKey() }
+        }
+        let resignedKey = center.addObserver(forName: NSWindow.didResignKeyNotification, object: window, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.stateMachine.markResignedKey() }
+        }
+        keyObservers = [becameKey, resignedKey]
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        stateMachine.markDidClose()
     }
 
     private func registerLoginItemIfNeeded() {

--- a/ccfocus-app/ccfocus-app/CcfocusApp.swift
+++ b/ccfocus-app/ccfocus-app/CcfocusApp.swift
@@ -52,7 +52,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         hotkeyController.onToggleFocus = { [weak self] in self?.handleHotkey() }
         hotkeyController.start()
 
+        setupMainMenu()
         observeKeyWindowNotifications()
+    }
+
+    private func setupMainMenu() {
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+        let appMenu = NSMenu()
+        let settingsItem = NSMenuItem(
+            title: "Settings…",
+            action: #selector(openSettingsFromMenu),
+            keyEquivalent: ","
+        )
+        settingsItem.keyEquivalentModifierMask = .command
+        settingsItem.target = self
+        appMenu.addItem(settingsItem)
+        appMenuItem.submenu = appMenu
+        NSApp.mainMenu = mainMenu
+    }
+
+    @objc private func openSettingsFromMenu() {
+        settingsWindowController.show()
     }
 
     @objc private func togglePopover() {
@@ -64,15 +86,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     private func handleHotkey() {
-        let action = stateMachine.handleHotkey()
-        switch action {
-        case .showAndFocus:
+        if popover.isShown {
+            let isKey = popover.contentViewController?.view.window?.isKeyWindow ?? false
+            if isKey {
+                popover.performClose(nil)
+            } else {
+                focusPopover()
+            }
+        } else {
             showPopoverUnfocused()
             focusPopover()
-        case .focus:
-            focusPopover()
-        case .close:
-            popover.performClose(nil)
         }
     }
 
@@ -95,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     private func handleKeyDown(_ event: NSEvent) -> Bool {
-        guard stateMachine.state == .openFocused else { return false }
+        guard popover.contentViewController?.view.window?.isKeyWindow == true else { return false }
         if event.keyCode == 53 {
             popover.performClose(nil)
             return true

--- a/ccfocus-app/ccfocus-app/CcfocusApp.swift
+++ b/ccfocus-app/ccfocus-app/CcfocusApp.swift
@@ -80,8 +80,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         guard let button = statusItem.button else { return }
         if !popover.isShown {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            stateMachine.markOpenedUnfocused()
             observeKeyWindowNotifications()
+            stateMachine.markOpenedUnfocused()
         }
     }
 

--- a/ccfocus-app/ccfocus-app/HotkeyController.swift
+++ b/ccfocus-app/ccfocus-app/HotkeyController.swift
@@ -1,0 +1,13 @@
+import Foundation
+import KeyboardShortcuts
+
+@MainActor
+final class HotkeyController {
+    var onToggleFocus: (() -> Void)?
+
+    func start() {
+        KeyboardShortcuts.onKeyDown(for: .toggleFocus) { [weak self] in
+            self?.onToggleFocus?()
+        }
+    }
+}

--- a/ccfocus-app/ccfocus-app/KeyActionResolver.swift
+++ b/ccfocus-app/ccfocus-app/KeyActionResolver.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum KeyActionResolver {
+    static let maxIndex = 10
+
+    static func numberIndex(forCharacter c: Character) -> Int? {
+        switch c {
+        case "1": return 0
+        case "2": return 1
+        case "3": return 2
+        case "4": return 3
+        case "5": return 4
+        case "6": return 5
+        case "7": return 6
+        case "8": return 7
+        case "9": return 8
+        case "0": return 9
+        default: return nil
+        }
+    }
+
+    static func select(from entries: [SessionEntry], numberIndex index: Int) -> SessionEntry? {
+        guard index >= 0, index < maxIndex, index < entries.count else { return nil }
+        return entries[index]
+    }
+}

--- a/ccfocus-app/ccfocus-app/KeyHandlingHostingView.swift
+++ b/ccfocus-app/ccfocus-app/KeyHandlingHostingView.swift
@@ -1,0 +1,16 @@
+import AppKit
+import SwiftUI
+
+final class KeyHandlingHostingView<Content: View>: NSHostingView<Content> {
+    var onKeyDown: ((NSEvent) -> Bool)?
+
+    override var acceptsFirstResponder: Bool { true }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        if let onKeyDown, onKeyDown(event) {
+            return
+        }
+        super.keyDown(with: event)
+    }
+}

--- a/ccfocus-app/ccfocus-app/KeyboardShortcutsNames.swift
+++ b/ccfocus-app/ccfocus-app/KeyboardShortcutsNames.swift
@@ -1,0 +1,8 @@
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    static let toggleFocus = Self(
+        "toggleFocus",
+        default: .init(.f, modifiers: [.command, .option])
+    )
+}

--- a/ccfocus-app/ccfocus-app/MenuBarView.swift
+++ b/ccfocus-app/ccfocus-app/MenuBarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuBarView: View {
     @ObservedObject var state: AppState
     var onDismiss: () -> Void = {}
+    var onOpenSettings: () -> Void = {}
     @State private var showDeceased = false
 
     private var activeSessions: [SessionEntry] {
@@ -56,6 +57,18 @@ struct MenuBarView: View {
                     }
                     .frame(height: height)
                 }
+            }
+            Divider()
+            HStack {
+                Color.clear.frame(width: 10, height: 10)
+                Text("Settings").foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(4)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                onDismiss()
+                onOpenSettings()
             }
             Divider()
             HStack {

--- a/ccfocus-app/ccfocus-app/MenuBarView.swift
+++ b/ccfocus-app/ccfocus-app/MenuBarView.swift
@@ -25,8 +25,8 @@ struct MenuBarView: View {
                 }
                 .padding(4)
             } else {
-                ForEach(activeSessions, id: \.sessionId) { s in
-                    row(s)
+                ForEach(Array(activeSessions.enumerated()), id: \.element.sessionId) { idx, s in
+                    row(s, numberHint: numberHint(forIndex: idx))
                 }
             }
             if !deceasedSessions.isEmpty {
@@ -50,7 +50,7 @@ struct MenuBarView: View {
                     ScrollView(showsIndicators: false) {
                         VStack(alignment: .leading, spacing: 4) {
                             ForEach(deceasedSessions, id: \.sessionId) { s in
-                                row(s)
+                                row(s, numberHint: nil)
                             }
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -63,6 +63,7 @@ struct MenuBarView: View {
                 Color.clear.frame(width: 10, height: 10)
                 Text("Settings").foregroundStyle(.secondary)
                 Spacer()
+                Text("⌘,").font(.system(.caption, design: .monospaced)).foregroundStyle(.tertiary)
             }
             .padding(4)
             .contentShape(Rectangle())
@@ -75,7 +76,7 @@ struct MenuBarView: View {
                 Color.clear.frame(width: 10, height: 10)
                 Text("Quit").foregroundStyle(.secondary)
                 Spacer()
-                Text("⌘Q").font(.caption).foregroundStyle(.tertiary)
+                Text("⌘Q").font(.system(.caption, design: .monospaced)).foregroundStyle(.tertiary)
             }
             .padding(4)
             .contentShape(Rectangle())
@@ -92,7 +93,12 @@ struct MenuBarView: View {
         }
     }
 
-    private func row(_ s: SessionEntry) -> some View {
+    private func numberHint(forIndex idx: Int) -> String? {
+        guard idx < 10 else { return nil }
+        return idx == 9 ? "0" : String(idx + 1)
+    }
+
+    private func row(_ s: SessionEntry, numberHint: String?) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack {
                 Circle().fill(color(for: s.status)).frame(width: 10, height: 10)
@@ -105,6 +111,9 @@ struct MenuBarView: View {
                 if let b = s.gitBranch { Text("[\(b)]").foregroundStyle(.secondary) }
                 Spacer()
                 Text(relativeAge(s.lastEventTs)).foregroundStyle(.secondary)
+                if let numberHint {
+                    Text(numberHint).font(.system(.caption, design: .monospaced)).foregroundStyle(.tertiary)
+                }
             }
             if s.status == .waitingInput, let msg = s.lastMessage {
                 Text(msg).font(.caption).foregroundStyle(.orange).padding(.leading, 16)

--- a/ccfocus-app/ccfocus-app/PopoverState.swift
+++ b/ccfocus-app/ccfocus-app/PopoverState.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum PopoverState {
+    case closed
+    case openUnfocused
+    case openFocused
+}
+
+enum HotkeyAction {
+    case showAndFocus
+    case focus
+    case close
+}
+
+struct PopoverStateMachine {
+    private(set) var state: PopoverState = .closed
+
+    mutating func handleHotkey() -> HotkeyAction {
+        switch state {
+        case .closed:
+            return .showAndFocus
+        case .openUnfocused:
+            return .focus
+        case .openFocused:
+            return .close
+        }
+    }
+
+    mutating func markOpenedUnfocused() {
+        state = .openUnfocused
+    }
+
+    mutating func markOpenedFocused() {
+        state = .openFocused
+    }
+
+    mutating func markBecameKey() {
+        if state != .closed {
+            state = .openFocused
+        }
+    }
+
+    mutating func markResignedKey() {
+        if state == .openFocused {
+            state = .openUnfocused
+        }
+    }
+
+    mutating func markDidClose() {
+        state = .closed
+    }
+}

--- a/ccfocus-app/ccfocus-app/SettingsView.swift
+++ b/ccfocus-app/ccfocus-app/SettingsView.swift
@@ -1,0 +1,14 @@
+import KeyboardShortcuts
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Form {
+            Section("Keyboard Shortcuts") {
+                KeyboardShortcuts.Recorder("Toggle & focus popover", name: .toggleFocus)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+}

--- a/ccfocus-app/ccfocus-app/SettingsView.swift
+++ b/ccfocus-app/ccfocus-app/SettingsView.swift
@@ -3,12 +3,17 @@ import SwiftUI
 
 struct SettingsView: View {
     var body: some View {
-        Form {
-            Section("Keyboard Shortcuts") {
-                KeyboardShortcuts.Recorder("Toggle & focus popover", name: .toggleFocus)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Keyboard Shortcuts")
+                .font(.headline)
+            HStack {
+                Text("Toggle & focus popover:")
+                Spacer()
+                KeyboardShortcuts.Recorder(for: .toggleFocus)
             }
+            Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 420)
+        .frame(width: 420, height: 140, alignment: .topLeading)
     }
 }

--- a/ccfocus-app/ccfocus-app/SettingsWindowController.swift
+++ b/ccfocus-app/ccfocus-app/SettingsWindowController.swift
@@ -12,9 +12,15 @@ final class SettingsWindowController {
             return
         }
         let hosting = NSHostingController(rootView: SettingsView())
-        let window = NSWindow(contentViewController: hosting)
+        let contentRect = NSRect(x: 0, y: 0, width: 420, height: 140)
+        let window = NSWindow(
+            contentRect: contentRect,
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
         window.title = "ccfocus Settings"
-        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.contentViewController = hosting
         window.isReleasedWhenClosed = false
         window.center()
         self.window = window

--- a/ccfocus-app/ccfocus-app/SettingsWindowController.swift
+++ b/ccfocus-app/ccfocus-app/SettingsWindowController.swift
@@ -1,0 +1,24 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class SettingsWindowController {
+    private var window: NSWindow?
+
+    func show() {
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let hosting = NSHostingController(rootView: SettingsView())
+        let window = NSWindow(contentViewController: hosting)
+        window.title = "ccfocus Settings"
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.center()
+        self.window = window
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/ccfocus-app/ccfocus-appTests/KeyActionResolverTests.swift
+++ b/ccfocus-app/ccfocus-appTests/KeyActionResolverTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import ccfocus_app
+
+final class KeyActionResolverTests: XCTestCase {
+    func testKey1MapsToIndex0() {
+        XCTAssertEqual(KeyActionResolver.numberIndex(forCharacter: "1"), 0)
+    }
+
+    func testKey9MapsToIndex8() {
+        XCTAssertEqual(KeyActionResolver.numberIndex(forCharacter: "9"), 8)
+    }
+
+    func testKey0MapsToIndex9() {
+        XCTAssertEqual(KeyActionResolver.numberIndex(forCharacter: "0"), 9)
+    }
+
+    func testNonDigitReturnsNil() {
+        XCTAssertNil(KeyActionResolver.numberIndex(forCharacter: "a"))
+        XCTAssertNil(KeyActionResolver.numberIndex(forCharacter: " "))
+    }
+
+    func testSelectReturnsEntryWithinBounds() {
+        let entries = Self.makeEntries(count: 5)
+        let selected = KeyActionResolver.select(from: entries, numberIndex: 2)
+        XCTAssertEqual(selected?.sessionId, "s2")
+    }
+
+    func testSelectReturnsNilWhenOutOfBounds() {
+        let entries = Self.makeEntries(count: 3)
+        XCTAssertNil(KeyActionResolver.select(from: entries, numberIndex: 5))
+    }
+
+    func testSelectReturnsNilWhenEmpty() {
+        XCTAssertNil(KeyActionResolver.select(from: [], numberIndex: 0))
+    }
+
+    func testSelectRespectsTenItemLimit() {
+        let entries = Self.makeEntries(count: 15)
+        let selected = KeyActionResolver.select(from: entries, numberIndex: 9)
+        XCTAssertEqual(selected?.sessionId, "s9")
+        XCTAssertNil(KeyActionResolver.select(from: entries, numberIndex: 10))
+    }
+
+    private static func makeEntries(count: Int) -> [SessionEntry] {
+        (0..<count).map { i in
+            SessionEntry(
+                sessionId: "s\(i)",
+                terminalId: nil,
+                cwd: "/tmp/\(i)",
+                gitBranch: nil,
+                claudePid: nil,
+                claudeStartTime: nil,
+                claudeComm: nil,
+                status: .running,
+                lastEventTs: "",
+                lastMessage: nil,
+                deceasedReason: nil,
+                startedAt: ""
+            )
+        }
+    }
+}

--- a/ccfocus-app/ccfocus-appTests/PopoverStateTests.swift
+++ b/ccfocus-app/ccfocus-appTests/PopoverStateTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import ccfocus_app
+
+final class PopoverStateTests: XCTestCase {
+    func testInitialStateIsClosed() {
+        let machine = PopoverStateMachine()
+        XCTAssertEqual(machine.state, .closed)
+    }
+
+    func testHotkeyFromClosedRequestsOpenAndFocus() {
+        var machine = PopoverStateMachine()
+        let action = machine.handleHotkey()
+        XCTAssertEqual(action, .showAndFocus)
+    }
+
+    func testHotkeyFromOpenUnfocusedRequestsFocus() {
+        var machine = PopoverStateMachine()
+        machine.markOpenedUnfocused()
+        let action = machine.handleHotkey()
+        XCTAssertEqual(action, .focus)
+    }
+
+    func testHotkeyFromOpenFocusedRequestsClose() {
+        var machine = PopoverStateMachine()
+        machine.markOpenedUnfocused()
+        machine.markBecameKey()
+        let action = machine.handleHotkey()
+        XCTAssertEqual(action, .close)
+    }
+
+    func testBecameKeyTransitionsToFocused() {
+        var machine = PopoverStateMachine()
+        machine.markOpenedUnfocused()
+        machine.markBecameKey()
+        XCTAssertEqual(machine.state, .openFocused)
+    }
+
+    func testResignKeyDemotesFocusedToUnfocused() {
+        var machine = PopoverStateMachine()
+        machine.markOpenedUnfocused()
+        machine.markBecameKey()
+        machine.markResignedKey()
+        XCTAssertEqual(machine.state, .openUnfocused)
+    }
+
+    func testResignKeyOnClosedIsNoop() {
+        var machine = PopoverStateMachine()
+        machine.markResignedKey()
+        XCTAssertEqual(machine.state, .closed)
+    }
+
+    func testDidCloseTransitionsToClosed() {
+        var machine = PopoverStateMachine()
+        machine.markOpenedUnfocused()
+        machine.markDidClose()
+        XCTAssertEqual(machine.state, .closed)
+    }
+}

--- a/ccfocus-app/project.yml
+++ b/ccfocus-app/project.yml
@@ -3,12 +3,18 @@ options:
   bundleIdPrefix: com.negipo
   deploymentTarget:
     macOS: "13.0"
+packages:
+  KeyboardShortcuts:
+    url: https://github.com/sindresorhus/KeyboardShortcuts
+    from: "2.0.0"
 targets:
   ccfocus-app:
     type: application
     platform: macOS
     sources:
       - path: ccfocus-app
+    dependencies:
+      - package: KeyboardShortcuts
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.negipo.ccfocus-app


### PR DESCRIPTION
## Summary

- Global hotkey (default ⌘⌥F, customizable in Settings) toggles the popover with focus
- Number keys (1-9, 0) select the corresponding active session and jump to its Ghostty pane
- ESC closes the popover when focused
- New Settings window hosts KeyboardShortcuts.Recorder; accessible via popover menu or ⌘, (while app is active)

## Known follow-ups

- ⌘W (close window) is not wired up because `AppDelegate.setupMainMenu` replaces the SwiftUI-provided File menu. Users can close Settings with the red title-bar button for now.
- `PopoverStateMachine` is implemented and tested but no longer on the hotkey/keyDown code path (they now read `popover.isShown` / `window.isKeyWindow` directly). Consider removing it if it stays unused.
- On AppKit `@main` bootstrap the popover renders ~138px lower than SwiftUI `@main` App with identical `button.window.frame`; root cause unresolved, so the SwiftUI App form is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)