### PR TITLE
fix: prevent popover focus steal and long-branch layout break

### DIFF
--- a/ccfocus-app/ccfocus-app/CcfocusApp.swift
+++ b/ccfocus-app/ccfocus-app/CcfocusApp.swift
@@ -102,6 +102,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func showPopoverUnfocused() {
         guard let button = statusItem.button else { return }
         if !popover.isShown {
+            if let hostingView = popover.contentViewController?.view as? KeyHandlingHostingView<MenuBarView> {
+                hostingView.wantsKeyboardFocus = false
+            }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             observeKeyWindowNotifications()
             stateMachine.markOpenedUnfocused()
@@ -111,7 +114,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func focusPopover() {
         NSApp.activate(ignoringOtherApps: true)
         if let window = popover.contentViewController?.view.window,
-           let hostingView = popover.contentViewController?.view {
+           let hostingView = popover.contentViewController?.view as? KeyHandlingHostingView<MenuBarView> {
+            hostingView.wantsKeyboardFocus = true
             window.makeKeyAndOrderFront(nil)
             window.makeFirstResponder(hostingView)
         }
@@ -153,6 +157,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     func popoverDidClose(_ notification: Notification) {
+        if let hostingView = popover.contentViewController?.view as? KeyHandlingHostingView<MenuBarView> {
+            hostingView.wantsKeyboardFocus = false
+        }
         stateMachine.markDidClose()
     }
 

--- a/ccfocus-app/ccfocus-app/KeyHandlingHostingView.swift
+++ b/ccfocus-app/ccfocus-app/KeyHandlingHostingView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 final class KeyHandlingHostingView<Content: View>: NSHostingView<Content> {
     var onKeyDown: ((NSEvent) -> Bool)?
+    var wantsKeyboardFocus: Bool = false
 
-    override var acceptsFirstResponder: Bool { true }
+    override var acceptsFirstResponder: Bool { wantsKeyboardFocus }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func keyDown(with event: NSEvent) {

--- a/ccfocus-app/ccfocus-app/MenuBarView.swift
+++ b/ccfocus-app/ccfocus-app/MenuBarView.swift
@@ -107,8 +107,16 @@ struct MenuBarView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
-                Text((s.cwd as NSString).lastPathComponent).fontWeight(s.status == .waitingInput ? .semibold : .regular)
-                if let b = s.gitBranch { Text("[\(b)]").foregroundStyle(.secondary) }
+                Text((s.cwd as NSString).lastPathComponent)
+                    .fontWeight(s.status == .waitingInput ? .semibold : .regular)
+                    .lineLimit(1)
+                if let b = s.gitBranch {
+                    Text("[\(b)]")
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .layoutPriority(-1)
+                }
                 Spacer()
                 Text(relativeAge(s.lastEventTs)).foregroundStyle(.secondary)
                 if let numberHint {


### PR DESCRIPTION
## Summary

- Popover was stealing focus from the user's foreground app when it appeared for a notification. Root cause: `KeyHandlingHostingView.acceptsFirstResponder` returned `true` unconditionally (introduced in #6), so showing the popover promoted the hosting view to first responder, which keyed the popover window and activated the app.
- Gate `acceptsFirstResponder` behind a `wantsKeyboardFocus` flag. `showPopoverUnfocused()` (menu bar click / notification path) keeps it `false`; `focusPopover()` (global hotkey path) sets it `true`, and `popoverDidClose` resets.
- Also fix the session row layout breaking when the git branch name is long (wrapping two lines and squeezing age/number hint) by applying `lineLimit(1)`, `.truncationMode(.middle)`, and `.layoutPriority(-1)` to the branch label.

## Test plan

- [x] `xcodebuild test` passes
- [x] Menu bar click / notification → popover opens without stealing focus from the foreground app
- [x] ⌘⌥F → popover opens and ccfocus becomes frontmost, number keys / ESC work
- [x] Long branch names truncate cleanly on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)