### PR TITLE
fix: show idle status for freshly-started Claude Code sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ ccfocusのUI変更を検証する際:
 pkill -x ccfocus 2>/dev/null
 xcodegen generate --spec ccfocus/project.yml --project ccfocus/
 xcodebuild -project ccfocus/ccfocus.xcodeproj -scheme ccfocus -configuration Debug build 2>&1 | tail -5
-open ~/Library/Developer/Xcode/DerivedData/ccfocus-*/Build/Products/Debug/ccfocus.app
+ls ~/Library/Developer/Xcode/DerivedData/ | rg ccfocus  # <hash> を確認 (複数残っていることがある)
+open ~/Library/Developer/Xcode/DerivedData/ccfocus-<hash>/Build/Products/Debug/ccfocus.app
 ```
 
 ccfocus-loggerの手動テスト:

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -88,7 +88,7 @@ struct MenuBarView: View {
 
     private var isUnlinked: (SessionEntry) -> Bool {
         { s in
-            [.running, .waitingInput, .done].contains(s.status)
+            [.idle, .running, .waitingInput, .done].contains(s.status)
                 && state.effectiveTerminalId(for: s) == nil
         }
     }
@@ -129,11 +129,15 @@ struct MenuBarView: View {
             if s.status == .done, s.doneNotified {
                 Text("done").font(.caption).foregroundStyle(.secondary).padding(.leading, 16)
             }
+            if s.status == .idle {
+                Text("idle").font(.caption).foregroundStyle(.secondary).padding(.leading, 16)
+            }
         }
         .padding(4)
         .background(
             s.status == .waitingInput ? Color.orange.opacity(0.1) :
             s.status == .done && s.doneNotified ? Color.gray.opacity(0.1) :
+            s.status == .idle ? Color.gray.opacity(0.1) :
             Color.clear
         )
         .contentShape(Rectangle())

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -149,6 +149,7 @@ struct MenuBarView: View {
 
     private func color(for s: SessionStatus) -> Color {
         switch s {
+        case .idle: return .gray
         case .running: return .green
         case .waitingInput: return .orange
         case .done: return .gray

--- a/ccfocus/ccfocus/SessionRegistry.swift
+++ b/ccfocus/ccfocus/SessionRegistry.swift
@@ -40,7 +40,7 @@ struct SessionRegistry {
                 claudePid: s.claudePid,
                 claudeStartTime: s.claudeStartTime,
                 claudeComm: s.claudeComm,
-                status: .running,
+                status: .idle,
                 lastEventTs: ev.ts,
                 lastMessage: nil,
                 deceasedReason: nil,
@@ -110,7 +110,7 @@ extension SessionRegistry {
         for (sid, e) in sessions {
             guard let d = fmt.date(from: e.lastEventTs) else { continue }
             let age = now.timeIntervalSince(d)
-            if e.status == .running || e.status == .waitingInput || e.status == .done {
+            if e.status == .idle || e.status == .running || e.status == .waitingInput || e.status == .done {
                 if age >= 30 * 60 { mutate(sid) { $0.status = .stale } }
             }
             if e.status == .stale && e.claudePid == nil && age >= 2.5 * 3600 {

--- a/ccfocus/ccfocus/SessionStatus.swift
+++ b/ccfocus/ccfocus/SessionStatus.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum SessionStatus: String, Equatable {
+    case idle
     case running
     case waitingInput = "waiting_input"
     case done
@@ -21,7 +22,7 @@ extension SessionStatus {
     static func transitioned(current: SessionStatus?, event: EventTransitionKind) -> SessionStatus {
         if current == .deceased { return .deceased }
         switch (current, event) {
-        case (_, .sessionStart): return .running
+        case (_, .sessionStart): return .idle
         case (_, .notification): return .waitingInput
         case (_, .preToolUse): return .running
         case (_, .stop): return .done

--- a/ccfocus/ccfocusTests/SessionRegistryTests.swift
+++ b/ccfocus/ccfocusTests/SessionRegistryTests.swift
@@ -16,7 +16,7 @@ final class SessionRegistryTests: XCTestCase {
         let s = reg.sessions["s1"]!
         XCTAssertEqual(s.terminalId, "T1")
         XCTAssertEqual(s.gitBranch, "main")
-        XCTAssertEqual(s.status, .running)
+        XCTAssertEqual(s.status, .idle)
     }
 
     func testNotificationMovesToWaitingInput() throws {
@@ -39,7 +39,20 @@ final class SessionRegistryTests: XCTestCase {
         var reg = SessionRegistry()
         for e in events { reg.apply(e) }
         XCTAssertEqual(reg.sessions["s1"]?.status, .deceased)
-        XCTAssertEqual(reg.sessions["s2"]?.status, .running)
+        XCTAssertEqual(reg.sessions["s2"]?.status, .idle)
+    }
+
+    func testIdleSessionBecomesStaleAfter30Min() throws {
+        let events = try parse([
+            #"{"ts":"2026-04-16T09:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/a","git_branch":null,"claude_pid":null,"claude_start_time":null,"claude_comm":null}"#
+        ])
+        var reg = SessionRegistry()
+        for e in events { reg.apply(e) }
+        XCTAssertEqual(reg.sessions["s1"]?.status, .idle)
+
+        let now = ISO8601DateFormatter().date(from: "2026-04-16T09:31:00Z")!
+        reg.applyStaleAfter(now)
+        XCTAssertEqual(reg.sessions["s1"]?.status, .stale)
     }
 
     func testSortedByLastEventDesc() throws {

--- a/ccfocus/ccfocusTests/SessionStatusTests.swift
+++ b/ccfocus/ccfocusTests/SessionStatusTests.swift
@@ -2,8 +2,24 @@ import XCTest
 @testable import ccfocus
 
 final class SessionStatusTests: XCTestCase {
-    func testStartToRunning() {
-        XCTAssertEqual(SessionStatus.transitioned(current: nil, event: .sessionStart), .running)
+    func testStartToIdle() {
+        XCTAssertEqual(SessionStatus.transitioned(current: nil, event: .sessionStart), .idle)
+    }
+
+    func testIdleToRunningOnUserPromptSubmit() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .idle, event: .userPromptSubmit), .running)
+    }
+
+    func testIdleToRunningOnPreToolUse() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .idle, event: .preToolUse), .running)
+    }
+
+    func testIdleToWaitingInputOnNotification() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .idle, event: .notification), .waitingInput)
+    }
+
+    func testIdleToDoneOnStop() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .idle, event: .stop), .done)
     }
 
     func testNotificationSetsWaitingInput() {


### PR DESCRIPTION
Closes #8

## What

SessionStart 直後のセッションをグリーン (`.running`) から新しい `.idle` 状態 (グレー + `idle` ラベル) に変更。