### PR TITLE
fix: resolve terminal_id by excluding live claimed panes + include idle sessions in liveness check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,9 @@ ccfocus-loggerの手動テスト:
 echo '{"session_id":"test","cwd":"/tmp"}' | CCFOCUS_LOGGER_DETACHED=1 cargo run -p ccfocus-logger -- stop
 \cat ~/Library/Application\ Support/ccfocus/events/$(date +%Y-%m-%d).jsonl
 ```
+
+The binary invoked by Claude Code hooks is `~/.cargo/bin/ccfocus-logger`, placed by `cargo install --path ccfocus-logger --locked`. Re-install before verifying code changes through the real hook path:
+
+```bash
+cargo install --path ccfocus-logger --locked
+```

--- a/ccfocus-logger/src/commands/session_start.rs
+++ b/ccfocus-logger/src/commands/session_start.rs
@@ -1,11 +1,13 @@
 use crate::event::{Event, EventKind};
 use crate::ghostty::find_terminal_id_with_retry;
 use crate::git::{git_branch, RealRunner};
-use crate::log_path::log_file_for_now;
+use crate::log_path::{events_dir, log_file_for_now};
+use crate::log_reader::collect_live_claimed_terminal_ids;
 use crate::log_writer::append_event_to;
 use crate::timestamp::now_iso8601;
 use anyhow::Result;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::io::Read;
 use std::time::Duration;
 
@@ -21,8 +23,17 @@ pub fn run() -> Result<()> {
     let payload: HookPayload = serde_json::from_str(&buf)?;
 
     let runner = RealRunner;
-    let terminal_id =
-        find_terminal_id_with_retry(&runner, &payload.cwd, 5, Duration::from_millis(100));
+    let claimed = match events_dir() {
+        Ok(dir) => collect_live_claimed_terminal_ids(&runner, &dir),
+        Err(_) => HashSet::new(),
+    };
+    let terminal_id = find_terminal_id_with_retry(
+        &runner,
+        &payload.cwd,
+        &claimed,
+        5,
+        Duration::from_millis(100),
+    );
     let git_branch = git_branch(&runner, &payload.cwd).unwrap_or(None);
 
     let claude_pid = std::env::var("CCFOCUS_CLAUDE_PID")

--- a/ccfocus-logger/src/ghostty.rs
+++ b/ccfocus-logger/src/ghostty.rs
@@ -1,5 +1,6 @@
 use crate::git::CommandRunner;
 use anyhow::Result;
+use std::collections::HashSet;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -72,6 +73,14 @@ pub fn parse_ghostty_dump(s: &str) -> Vec<Term> {
 }
 
 pub fn pick_match(terms: &[Term], cwd: &str) -> MatchResult {
+    pick_match_excluding(terms, cwd, &HashSet::new())
+}
+
+pub fn pick_match_excluding(
+    terms: &[Term],
+    cwd: &str,
+    claimed: &HashSet<String>,
+) -> MatchResult {
     let canonical_cwd = std::fs::canonicalize(cwd)
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| cwd.to_string());
@@ -81,7 +90,9 @@ pub fn pick_match(terms: &[Term], cwd: &str) -> MatchResult {
             let canonical_wd = std::fs::canonicalize(&t.wd)
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| t.wd.clone());
-            canonical_wd == canonical_cwd && t.name.contains("Claude Code")
+            canonical_wd == canonical_cwd
+                && t.name.contains("Claude Code")
+                && !claimed.contains(&t.id)
         })
         .collect();
     match cands.len() {
@@ -99,6 +110,7 @@ pub fn enumerate_terminals(runner: &impl CommandRunner) -> Result<Vec<Term>> {
 pub fn find_terminal_id_with_retry(
     runner: &impl CommandRunner,
     cwd: &str,
+    claimed: &HashSet<String>,
     max_attempts: usize,
     interval: Duration,
 ) -> Option<String> {
@@ -109,7 +121,7 @@ pub fn find_terminal_id_with_retry(
         let Ok(terms) = enumerate_terminals(runner) else {
             continue;
         };
-        if let MatchResult::Unique(id) = pick_match(&terms, cwd) {
+        if let MatchResult::Unique(id) = pick_match_excluding(&terms, cwd, claimed) {
             return Some(id);
         }
     }
@@ -187,6 +199,67 @@ mod tests {
             wd: "/foo".into(),
         }];
         let m = pick_match(&terms, "/foo");
+        assert_eq!(m, MatchResult::Unique("T1".into()));
+    }
+
+    #[test]
+    fn excluding_claimed_resolves_to_remaining() {
+        let terms = vec![
+            Term {
+                id: "T1".into(),
+                name: "Claude Code".into(),
+                wd: "/foo".into(),
+            },
+            Term {
+                id: "T2".into(),
+                name: "Claude Code".into(),
+                wd: "/foo".into(),
+            },
+        ];
+        let claimed = HashSet::from(["T1".to_string()]);
+        let m = pick_match_excluding(&terms, "/foo", &claimed);
+        assert_eq!(m, MatchResult::Unique("T2".into()));
+    }
+
+    #[test]
+    fn excluding_claimed_when_all_claimed_returns_none() {
+        let terms = vec![
+            Term {
+                id: "T1".into(),
+                name: "Claude Code".into(),
+                wd: "/foo".into(),
+            },
+            Term {
+                id: "T2".into(),
+                name: "Claude Code".into(),
+                wd: "/foo".into(),
+            },
+        ];
+        let claimed = HashSet::from(["T1".to_string(), "T2".to_string()]);
+        let m = pick_match_excluding(&terms, "/foo", &claimed);
+        assert_eq!(m, MatchResult::None);
+    }
+
+    #[test]
+    fn excluding_claimed_not_in_terms_is_noop() {
+        let terms = vec![Term {
+            id: "T1".into(),
+            name: "Claude Code".into(),
+            wd: "/foo".into(),
+        }];
+        let claimed = HashSet::from(["T_OTHER".to_string()]);
+        let m = pick_match_excluding(&terms, "/foo", &claimed);
+        assert_eq!(m, MatchResult::Unique("T1".into()));
+    }
+
+    #[test]
+    fn excluding_empty_claimed_single_pane_matches() {
+        let terms = vec![Term {
+            id: "T1".into(),
+            name: "Claude Code".into(),
+            wd: "/foo".into(),
+        }];
+        let m = pick_match_excluding(&terms, "/foo", &HashSet::new());
         assert_eq!(m, MatchResult::Unique("T1".into()));
     }
 }

--- a/ccfocus-logger/src/lib.rs
+++ b/ccfocus-logger/src/lib.rs
@@ -6,5 +6,6 @@ pub mod event;
 pub mod ghostty;
 pub mod git;
 pub mod log_path;
+pub mod log_reader;
 pub mod log_writer;
 pub mod timestamp;

--- a/ccfocus-logger/src/log_reader.rs
+++ b/ccfocus-logger/src/log_reader.rs
@@ -1,0 +1,241 @@
+use crate::event::{Event, EventKind};
+use crate::git::CommandRunner;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use time::{Date, OffsetDateTime, UtcOffset};
+
+#[derive(Debug, Clone)]
+struct Claim {
+    ts: String,
+    terminal_id: String,
+    claude_pid: u32,
+    claude_start_time: String,
+    claude_comm: String,
+}
+
+pub fn collect_live_claimed_terminal_ids(
+    runner: &impl CommandRunner,
+    dir: &Path,
+) -> HashSet<String> {
+    let dates = recent_dates();
+    let mut latest: HashMap<(u32, String), Claim> = HashMap::new();
+
+    for date in &dates {
+        let path = dir.join(format!(
+            "{:04}-{:02}-{:02}.jsonl",
+            date.year(),
+            u8::from(date.month()),
+            date.day()
+        ));
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(ev) = serde_json::from_str::<Event>(trimmed) else {
+                continue;
+            };
+            let EventKind::SessionStart {
+                terminal_id,
+                claude_pid,
+                claude_start_time,
+                claude_comm,
+                ..
+            } = ev.kind
+            else {
+                continue;
+            };
+            let (Some(terminal_id), Some(pid), Some(start), Some(comm)) =
+                (terminal_id, claude_pid, claude_start_time, claude_comm)
+            else {
+                continue;
+            };
+            let key = (pid, start.clone());
+            let claim = Claim {
+                ts: ev.ts,
+                terminal_id,
+                claude_pid: pid,
+                claude_start_time: start,
+                claude_comm: comm,
+            };
+            match latest.get(&key) {
+                Some(existing) if existing.ts >= claim.ts => {}
+                _ => {
+                    latest.insert(key, claim);
+                }
+            }
+        }
+    }
+
+    let mut claimed = HashSet::new();
+    for claim in latest.values() {
+        if is_alive(runner, claim) {
+            claimed.insert(claim.terminal_id.clone());
+        }
+    }
+    claimed
+}
+
+fn is_alive(runner: &impl CommandRunner, claim: &Claim) -> bool {
+    let pid_str = claim.claude_pid.to_string();
+    let Ok(out) = runner.run("ps", &["-p", &pid_str, "-o", "pid=,lstart=,comm="]) else {
+        return false;
+    };
+    let trimmed = out.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+    if parts.len() < 7 {
+        return false;
+    }
+    let Ok(pid) = parts[0].parse::<u32>() else {
+        return false;
+    };
+    if pid != claim.claude_pid {
+        return false;
+    }
+    let lstart = parts[1..6].join(" ");
+    let comm = parts[6..].join(" ");
+    lstart == claim.claude_start_time && comm == claim.claude_comm
+}
+
+fn recent_dates() -> Vec<Date> {
+    let offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
+    let now = OffsetDateTime::now_utc().to_offset(offset);
+    let today = now.date();
+    let yesterday = today.previous_day().unwrap_or(today);
+    vec![yesterday, today]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    struct PsRunner {
+        responses: RefCell<HashMap<String, std::result::Result<String, String>>>,
+    }
+
+    impl PsRunner {
+        fn new() -> Self {
+            Self {
+                responses: RefCell::new(HashMap::new()),
+            }
+        }
+
+        fn set(&self, pid: &str, resp: std::result::Result<String, String>) {
+            self.responses.borrow_mut().insert(pid.to_string(), resp);
+        }
+    }
+
+    impl CommandRunner for PsRunner {
+        fn run(&self, prog: &str, args: &[&str]) -> Result<String> {
+            assert_eq!(prog, "ps");
+            assert_eq!(args[0], "-p");
+            let pid = args[1].to_string();
+            let map = self.responses.borrow();
+            match map.get(&pid) {
+                Some(Ok(s)) => Ok(s.clone()),
+                Some(Err(e)) => anyhow::bail!("{}", e),
+                None => anyhow::bail!("no stub for {}", pid),
+            }
+        }
+    }
+
+    fn write_today(dir: &Path, content: &str) -> PathBuf {
+        let offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
+        let now = OffsetDateTime::now_utc().to_offset(offset);
+        let date = now.date();
+        let name = format!(
+            "{:04}-{:02}-{:02}.jsonl",
+            date.year(),
+            u8::from(date.month()),
+            date.day()
+        );
+        let path = dir.join(name);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn includes_terminal_when_ps_matches() {
+        let tmp = TempDir::new().unwrap();
+        let line = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{line}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert_eq!(claimed, HashSet::from(["T1".to_string()]));
+    }
+
+    #[test]
+    fn drops_claim_when_ps_mismatches() {
+        let tmp = TempDir::new().unwrap();
+        let line = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{line}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Ok("111 Sat Apr 18 21:00:00 2026 claude\n".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert!(claimed.is_empty());
+    }
+
+    #[test]
+    fn drops_claim_when_ps_fails() {
+        let tmp = TempDir::new().unwrap();
+        let line = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{line}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Err("no such process".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert!(claimed.is_empty());
+    }
+
+    #[test]
+    fn latest_terminal_id_wins_for_duplicate_pid_start() {
+        let tmp = TempDir::new().unwrap();
+        let older = r#"{"ts":"2026-04-18T10:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T_OLD","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        let newer = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s2","terminal_id":"T_NEW","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{older}\n{newer}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert_eq!(claimed, HashSet::from(["T_NEW".to_string()]));
+    }
+
+    #[test]
+    fn ignores_null_terminal_id() {
+        let tmp = TempDir::new().unwrap();
+        let line = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":null,"cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{line}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert!(claimed.is_empty());
+    }
+
+    #[test]
+    fn skips_malformed_lines_but_picks_up_valid() {
+        let tmp = TempDir::new().unwrap();
+        let garbage = "this is not json";
+        let valid = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
+        write_today(tmp.path(), &format!("{garbage}\n{valid}\n"));
+        let runner = PsRunner::new();
+        runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
+        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
+        assert_eq!(claimed, HashSet::from(["T1".to_string()]));
+    }
+
+    #[test]
+    fn returns_empty_when_dir_missing() {
+        let runner = PsRunner::new();
+        let claimed = collect_live_claimed_terminal_ids(&runner, Path::new("/nonexistent/ccfocus/path"));
+        assert!(claimed.is_empty());
+    }
+}

--- a/ccfocus/ccfocus/AppState.swift
+++ b/ccfocus/ccfocus/AppState.swift
@@ -121,7 +121,7 @@ final class AppState: ObservableObject {
     private func runLivenessCheck() {
         let terms = LivenessChecker.ghosttyTerminalIds()
         for (sid, e) in registry.sessions {
-            if [.running, .waitingInput, .done, .stale].contains(e.status) == false { continue }
+            if [.idle, .running, .waitingInput, .done, .stale].contains(e.status) == false { continue }
             if let pid = e.claudePid, let st = e.claudeStartTime, let cm = e.claudeComm {
                 if let cur = LivenessChecker.queryPs(pid: pid) {
                     if !LivenessChecker.verify(expected: (pid, st, cm), current: cur) {


### PR DESCRIPTION
## What

- logger: resolve `terminal_id` by excluding panes already claimed by live claude processes, fixing `null` records when multiple Claude Code panes share a cwd
- app: include `.idle` sessions in the liveness check so ghost sessions get cleaned up

## How (sequence)

Before:

```mermaid
sequenceDiagram
    participant CC as new Claude Code
    participant L as logger
    participant G as Ghostty
    participant J as jsonl
    CC->>L: SessionStart {cwd}
    L->>G: enumerate
    G-->>L: [T1 "Claude Code" wd=X, T2 "Claude Code" wd=X]
    Note over L: pick_match → Multiple
    L->>J: append {terminal_id: null}
```

After:

```mermaid
sequenceDiagram
    participant CC as new Claude Code
    participant L as logger
    participant G as Ghostty
    participant J as jsonl
    CC->>L: SessionStart {cwd}
    L->>J: read session_starts
    L->>L: ps verify (pid, lstart) live → claimed={T1}
    L->>G: enumerate
    G-->>L: [T1, T2]
    Note over L: pick_match_excluding → Unique(T2)
    L->>J: append {terminal_id: T2}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)