### PR TITLE
feat: detect asking status from assistant text at Stop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ xcodebuild -project ccfocus/ccfocus.xcodeproj -scheme ccfocusTests -configuratio
 - コミット前にRustは`cargo test`と`cargo clippy`、Swiftは`xcodebuild test`を実行する
 - PreToolUse hookがツール呼び出しをブロックした場合、回避策を試みず、ユーザに報告して指示を待つ
 - ドキュメント (README.md等) は英語で記述する
+- セッション状態・色・ラベル・遷移・タイムアウト (30分staleや60秒idle→waitingInput等) の一覧はREADME.mdの「Session states」に記載している。状態/配色/遷移/タイムアウト値のいずれかに触れる変更を入れたら、必ずREADME.mdも同じコミットで更新する
 
 ## Manual Verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,10 @@ echo '{"session_id":"test","cwd":"/tmp"}' | CCFOCUS_LOGGER_DETACHED=1 cargo run 
 \cat ~/Library/Application\ Support/ccfocus/events/$(date +%Y-%m-%d).jsonl
 ```
 
-The binary invoked by Claude Code hooks is `~/.cargo/bin/ccfocus-logger`, placed by `cargo install --path ccfocus-logger --locked`. Re-install before verifying code changes through the real hook path:
+実 Claude Code セッションで動作検証したいときは dev ビルドで `ccfocus-logger` を差し替える (mise 管理下のシム経由で PATH を解決するため cargo install + mise reshim が必要):
 
 ```bash
-cargo install --path ccfocus-logger --locked
+make dev-install-logger    # cargo install --force + mise reshim で PATH の ccfocus-logger を差し替え
+# 新規 Claude Code セッションを立ち上げて検証
+make dev-uninstall-logger  # cargo uninstall + mise reshim で release symlink (/opt/homebrew/bin) に戻す
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +79,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -326,6 +337,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test clean
+.PHONY: build install test clean dev-install-logger dev-uninstall-logger
 
 build:
 	bash scripts/build-release.sh
@@ -9,6 +9,16 @@ install: build
 	cp -R dist/ccfocus.app /Applications/
 	ccfocus-logger install
 	@echo "ccfocus installed. Launch ccfocus from /Applications or reboot."
+
+dev-install-logger:
+	cargo install --path ccfocus-logger --force
+	mise reshim
+	@echo "dev ccfocus-logger installed via mise shim. Run 'make dev-uninstall-logger' to revert."
+
+dev-uninstall-logger:
+	cargo uninstall ccfocus-logger
+	mise reshim
+	@echo "dev ccfocus-logger removed. PATH now resolves to the release symlink again."
 
 test:
 	cargo test -p ccfocus-logger

--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ brew uninstall --cask ccfocus
 
 The uninstall preflight removes ccfocus entries from `~/.claude/settings.json`. Use `brew uninstall --zap --cask ccfocus` to also remove logs and preferences.
 
+## Session states
+
+Each tracked session appears in the menu bar with a colored dot and an optional label indicating its current state.
+
+States are listed from most to least urgent for the user to act on.
+
+| State          | Color       | Label       | Meaning                                                                     |
+|----------------|-------------|-------------|-----------------------------------------------------------------------------|
+| `asking`       | orange      | last text / `asking` | Claude ended its turn with a question — respond immediately        |
+| `waitingInput` | orange      | notification message | Claude Code emitted a Notification (permission prompt, or idle timeout) |
+| `running`      | green       | —           | Claude is working (prompt submitted, tool calls in flight)                  |
+| `idle`         | gray        | `idle`      | Session has started; waiting for the first user prompt                      |
+| `done`         | gray        | `done`      | Claude ended its turn without a question                                    |
+| `stale`        | dim gray    | —           | Session has not produced any event for 30+ minutes                          |
+| `deceased`     | faded gray  | —           | Claude process exited or Ghostty pane closed; collapsed at the bottom       |
+
+### Transitions
+
+- `session_start` puts a session into `idle`.
+- `user_prompt_submit` and `pre_tool_use` move it to `running`.
+- `stop` with a detected question-like ending goes to `asking`; otherwise `done`.
+- `notification` moves a session to `waitingInput`. Claude Code fires a Notification whenever it shows a permission prompt OR sits idle for about one minute, so a forgotten `done` session escalates to `waitingInput` roughly 60 seconds after the last event, regardless of whether asking-detection fired.
+- Any active state (`idle` / `running` / `asking` / `waitingInput` / `done`) becomes `stale` after 30 minutes without new events.
+- A `stale` session with no tracked Claude process is marked `deceased` after 2.5 hours.
+- `deceased` is terminal.
+
+The popover auto-opens when a session transitions into `asking`, `waitingInput`, or `done` so you can react without polling the menu bar.
+
+### How `asking` is detected
+
+At `stop` hook time the logger reads the tail of the session's transcript jsonl, extracts the most recent assistant text, and checks whether the last three non-empty lines contain a half- or full-width question mark or a polite-request pattern (`確認してください`, `試していただけ`, etc.). If the heuristic can't read the transcript, the session falls back to `done` and will still be caught by the 60-second idle `waitingInput` escalation.
+
 ## Building from source
 
 For development:

--- a/README.md
+++ b/README.md
@@ -47,19 +47,24 @@ States are listed from most to least urgent for the user to act on.
 
 ### Transitions
 
-- `session_start` puts a session into `idle`.
-- `user_prompt_submit` and `pre_tool_use` move it to `running`.
-- `stop` with a detected question-like ending goes to `asking`; otherwise `done`.
-- `notification` moves a session to `waitingInput`. Claude Code fires a Notification whenever it shows a permission prompt OR sits idle for about one minute, so a forgotten `done` session escalates to `waitingInput` roughly 60 seconds after the last event, regardless of whether asking-detection fired.
-- Any active state (`idle` / `running` / `asking` / `waitingInput` / `done`) becomes `stale` after 30 minutes without new events.
-- A `stale` session with no tracked Claude process is marked `deceased` after 2.5 hours.
+- `session_start` → `idle`.
+- `user_prompt_submit` and `pre_tool_use` → `running`.
+- `stop` with a detected question-like ending → `asking`; otherwise `done`.
+- `notification` → `waitingInput`. Claude Code emits a Notification both for permission prompts and for its own ~60-second idle timeout, so a forgotten `done` session escalates to `waitingInput` roughly one minute after the last event (regardless of whether asking-detection fired). This is the primary safety net for questions that the heuristic misses.
+- Any active state (`idle` / `running` / `asking` / `waitingInput` / `done`) → `stale` after 30 minutes without new events.
+- `stale` with no tracked Claude process → `deceased` after 2.5 hours.
 - `deceased` is terminal.
 
-The popover auto-opens when a session transitions into `asking`, `waitingInput`, or `done` so you can react without polling the menu bar.
+The popover auto-opens when a session transitions into `asking`, `waitingInput`, or `done`, so you can react without polling the menu bar.
 
 ### How `asking` is detected
 
-At `stop` hook time the logger reads the tail of the session's transcript jsonl, extracts the most recent assistant text, and checks whether the last three non-empty lines contain a half- or full-width question mark or a polite-request pattern (`確認してください`, `試していただけ`, etc.). If the heuristic can't read the transcript, the session falls back to `done` and will still be caught by the 60-second idle `waitingInput` escalation.
+At `stop` hook time the logger reads the tail of the session's transcript jsonl, extracts the most recent assistant text, and checks whether the last three non-empty lines contain either:
+
+- a half- or full-width question mark (`?` / `？`), or
+- a polite-request phrase — Japanese (`確認してください`, `試していただけ`, `教えてください`, ...) or English case-insensitive (`let me know`, `please confirm`, `please advise`).
+
+If the heuristic can't read the transcript (missing file, no assistant text yet), the session falls back to `done` and gets rescued by the 60-second idle `waitingInput` escalation described above.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -31,40 +31,17 @@ The uninstall preflight removes ccfocus entries from `~/.claude/settings.json`. 
 
 ## Session states
 
-Each tracked session appears in the menu bar with a colored dot and an optional label indicating its current state.
+Each tracked session appears in the menu bar with a colored dot and an optional label. States are listed in the order the user should handle them.
 
-States are listed from most to least urgent for the user to act on.
-
-| State          | Color       | Label       | Meaning                                                                     |
-|----------------|-------------|-------------|-----------------------------------------------------------------------------|
-| `asking`       | orange      | last text / `asking` | Claude ended its turn with a question — respond immediately        |
-| `waitingInput` | orange      | notification message | Claude Code emitted a Notification (permission prompt, or idle timeout) |
-| `running`      | green       | —           | Claude is working (prompt submitted, tool calls in flight)                  |
-| `idle`         | gray        | `idle`      | Session has started; waiting for the first user prompt                      |
-| `done`         | gray        | `done`      | Claude ended its turn without a question                                    |
-| `stale`        | dim gray    | —           | Session has not produced any event for 30+ minutes                          |
-| `deceased`     | faded gray  | —           | Claude process exited or Ghostty pane closed; collapsed at the bottom       |
-
-### Transitions
-
-- `session_start` → `idle`.
-- `user_prompt_submit` and `pre_tool_use` → `running`.
-- `stop` with a detected question-like ending → `asking`; otherwise `done`.
-- `notification` → `waitingInput`. Claude Code emits a Notification both for permission prompts and for its own ~60-second idle timeout, so a forgotten `done` session escalates to `waitingInput` roughly one minute after the last event (regardless of whether asking-detection fired). This is the primary safety net for questions that the heuristic misses.
-- Any active state (`idle` / `running` / `asking` / `waitingInput` / `done`) → `stale` after 30 minutes without new events.
-- `stale` with no tracked Claude process → `deceased` after 2.5 hours.
-- `deceased` is terminal.
-
-The popover auto-opens when a session transitions into `asking`, `waitingInput`, or `done`, so you can react without polling the menu bar.
-
-### How `asking` is detected
-
-At `stop` hook time the logger reads the tail of the session's transcript jsonl, extracts the most recent assistant text, and checks whether the last three non-empty lines contain either:
-
-- a half- or full-width question mark (`?` / `？`), or
-- a polite-request phrase — Japanese (`確認してください`, `試していただけ`, `教えてください`, ...) or English case-insensitive (`let me know`, `please confirm`, `please advise`).
-
-If the heuristic can't read the transcript (missing file, no assistant text yet), the session falls back to `done` and gets rescued by the 60-second idle `waitingInput` escalation described above.
+| State          | Color       | Label                | Meaning                                                                                 |
+|----------------|-------------|----------------------|-----------------------------------------------------------------------------------------|
+| `asking`       | orange      | last text / `asking` | Claude ended its turn with a question — respond immediately                             |
+| `waitingInput` | orange      | notification message | Claude Code emitted a Notification (permission prompt, or ~60s idle after `done`)       |
+| `running`      | green       | —                    | Claude is working (prompt submitted, tool call in flight)                               |
+| `idle`         | gray        | `idle`               | Session has started; waiting for the first user prompt                                  |
+| `done`         | gray        | `done`               | Claude ended its turn without a question; escalates to `waitingInput` after ~60s idle   |
+| `stale`        | dim gray    | —                    | No events for 30+ min; escalates to `deceased` after ~2.5h without a tracked process    |
+| `deceased`     | faded gray  | —                    | Claude process exited or Ghostty pane closed; terminal, collapsed at the bottom         |
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Each tracked session appears in the menu bar with a colored dot and an optional 
 |----------------|-------------|----------------------|-----------------------------------------------------------------------------------------|
 | `asking`       | orange      | last text / `asking` | Claude ended its turn with a question — respond immediately                             |
 | `waitingInput` | orange      | notification message | Claude Code emitted a Notification (permission prompt, or ~60s idle after `done`)       |
-| `running`      | green       | —                    | Claude is working (prompt submitted, tool call in flight)                               |
 | `idle`         | gray        | `idle`               | Session has started; waiting for the first user prompt                                  |
 | `done`         | gray        | `done`               | Claude ended its turn without a question; escalates to `waitingInput` after ~60s idle   |
+| `running`      | green       | —                    | Claude is working (prompt submitted, tool call in flight); you're waiting on Claude     |
 | `stale`        | dim gray    | —                    | No events for 30+ min; escalates to `deceased` after ~2.5h without a tracked process    |
 | `deceased`     | faded gray  | —                    | Claude process exited or Ghostty pane closed; terminal, collapsed at the bottom         |
 

--- a/ccfocus-logger/Cargo.toml
+++ b/ccfocus-logger/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+once_cell = "1"
+regex = "1"
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/ccfocus-logger/src/commands/stop.rs
+++ b/ccfocus-logger/src/commands/stop.rs
@@ -19,6 +19,7 @@ pub fn run() -> Result<()> {
         ts: now_iso8601(),
         kind: EventKind::Stop {
             session_id: p.session_id,
+            has_question: None,
         },
     };
     append_event_to(&log_file_for_now()?, &ev)?;

--- a/ccfocus-logger/src/commands/stop.rs
+++ b/ccfocus-logger/src/commands/stop.rs
@@ -2,24 +2,33 @@ use crate::event::{Event, EventKind};
 use crate::log_path::log_file_for_now;
 use crate::log_writer::append_event_to;
 use crate::timestamp::now_iso8601;
+use crate::transcript::{classify_has_question, last_assistant_text};
 use anyhow::Result;
 use serde::Deserialize;
 use std::io::Read;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 struct Payload {
     session_id: String,
+    #[serde(default)]
+    transcript_path: Option<PathBuf>,
 }
 
 pub fn run() -> Result<()> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf)?;
     let p: Payload = serde_json::from_str(&buf)?;
+    let has_question = p
+        .transcript_path
+        .as_deref()
+        .and_then(last_assistant_text)
+        .map(|t| classify_has_question(&t));
     let ev = Event {
         ts: now_iso8601(),
         kind: EventKind::Stop {
             session_id: p.session_id,
-            has_question: None,
+            has_question,
         },
     };
     append_event_to(&log_file_for_now()?, &ev)?;

--- a/ccfocus-logger/src/commands/stop.rs
+++ b/ccfocus-logger/src/commands/stop.rs
@@ -7,6 +7,10 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::io::Read;
 use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
+
+const TRANSCRIPT_SETTLE_DELAY: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Deserialize)]
 struct Payload {
@@ -19,6 +23,7 @@ pub fn run() -> Result<()> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf)?;
     let p: Payload = serde_json::from_str(&buf)?;
+    sleep(TRANSCRIPT_SETTLE_DELAY);
     let has_question = p
         .transcript_path
         .as_deref()

--- a/ccfocus-logger/src/event.rs
+++ b/ccfocus-logger/src/event.rs
@@ -25,6 +25,8 @@ pub enum EventKind {
     },
     Stop {
         session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        has_question: Option<bool>,
     },
     PreToolUse {
         session_id: String,

--- a/ccfocus-logger/src/lib.rs
+++ b/ccfocus-logger/src/lib.rs
@@ -9,3 +9,4 @@ pub mod log_path;
 pub mod log_reader;
 pub mod log_writer;
 pub mod timestamp;
+pub mod transcript;

--- a/ccfocus-logger/src/transcript.rs
+++ b/ccfocus-logger/src/transcript.rs
@@ -8,7 +8,7 @@ const TAIL_READ_LIMIT: u64 = 256 * 1024;
 
 static ASK_QMARK: Lazy<Regex> = Lazy::new(|| Regex::new(r"[?？]").unwrap());
 static ASK_POLITE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(確認してください|試していただけ|確認していただけ|教えていただけ|教えてください)")
+    Regex::new(r"(?i)(確認してください|試していただけ|確認していただけ|教えていただけ|教えてください|let me know|please confirm|please advise)")
         .unwrap()
 });
 
@@ -105,6 +105,26 @@ mod tests {
     #[test]
     fn empty_text_is_not_question() {
         assert!(!classify_has_question(""));
+    }
+
+    #[test]
+    fn english_let_me_know_is_question() {
+        assert!(classify_has_question("Built and tested.\nLet me know if you'd like any changes."));
+    }
+
+    #[test]
+    fn english_please_confirm_is_question() {
+        assert!(classify_has_question("Ready to proceed. Please confirm."));
+    }
+
+    #[test]
+    fn english_please_advise_case_insensitive_is_question() {
+        assert!(classify_has_question("Two options remain. please advise"));
+    }
+
+    #[test]
+    fn english_plain_done_is_not_question() {
+        assert!(!classify_has_question("Implementation complete.\nAll tests pass."));
     }
 
     use std::io::Write;

--- a/ccfocus-logger/src/transcript.rs
+++ b/ccfocus-logger/src/transcript.rs
@@ -1,11 +1,57 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+const TAIL_READ_LIMIT: u64 = 256 * 1024;
 
 static ASK_QMARK: Lazy<Regex> = Lazy::new(|| Regex::new(r"[?？]").unwrap());
 static ASK_POLITE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(確認してください|試していただけ|確認していただけ|教えていただけ|教えてください)")
         .unwrap()
 });
+
+pub fn last_assistant_text(path: &Path) -> Option<String> {
+    let size = std::fs::metadata(path).ok()?.len();
+    let read_bytes = size.min(TAIL_READ_LIMIT);
+    let mut f = File::open(path).ok()?;
+    if size > read_bytes {
+        f.seek(SeekFrom::End(-(read_bytes as i64))).ok()?;
+    }
+    let mut buf = Vec::with_capacity(read_bytes as usize);
+    f.read_to_end(&mut buf).ok()?;
+    let start = if size > read_bytes {
+        buf.iter().position(|&b| b == b'\n').map(|i| i + 1).unwrap_or(0)
+    } else {
+        0
+    };
+    let text = std::str::from_utf8(&buf[start..]).ok()?;
+    for line in text.lines().rev() {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+            continue;
+        }
+        let content = v
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array());
+        let Some(content) = content else { continue };
+        let joined: Vec<&str> = content
+            .iter()
+            .filter(|c| c.get("type").and_then(|t| t.as_str()) == Some("text"))
+            .filter_map(|c| c.get("text").and_then(|t| t.as_str()))
+            .collect();
+        if joined.is_empty() {
+            continue;
+        }
+        return Some(joined.join("\n"));
+    }
+    None
+}
 
 pub fn classify_has_question(text: &str) -> bool {
     let tail: String = text
@@ -59,5 +105,56 @@ mod tests {
     #[test]
     fn empty_text_is_not_question() {
         assert!(!classify_has_question(""));
+    }
+
+    use std::io::Write;
+
+    fn write_jsonl(path: &std::path::Path, lines: &[&str]) {
+        let mut f = std::fs::File::create(path).unwrap();
+        for line in lines {
+            writeln!(f, "{}", line).unwrap();
+        }
+    }
+
+    #[test]
+    fn last_assistant_text_returns_latest_text_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        write_jsonl(&path, &[
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"again"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second turn\nend?"}]}}"#,
+        ]);
+        let out = last_assistant_text(&path).unwrap();
+        assert!(out.contains("second turn"));
+        assert!(out.contains("end?"));
+    }
+
+    #[test]
+    fn last_assistant_text_joins_multiple_text_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        write_jsonl(&path, &[
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"part1"},{"type":"tool_use","id":"x","name":"R","input":{}},{"type":"text","text":"part2?"}]}}"#,
+        ]);
+        let out = last_assistant_text(&path).unwrap();
+        assert!(out.contains("part1"));
+        assert!(out.contains("part2?"));
+    }
+
+    #[test]
+    fn last_assistant_text_missing_file_returns_none() {
+        assert!(last_assistant_text(std::path::Path::new("/no/such/file.jsonl")).is_none());
+    }
+
+    #[test]
+    fn last_assistant_text_only_tool_use_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        write_jsonl(&path, &[
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x","name":"R","input":{}}]}}"#,
+        ]);
+        assert!(last_assistant_text(&path).is_none());
     }
 }

--- a/ccfocus-logger/src/transcript.rs
+++ b/ccfocus-logger/src/transcript.rs
@@ -1,0 +1,63 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static ASK_QMARK: Lazy<Regex> = Lazy::new(|| Regex::new(r"[?？]").unwrap());
+static ASK_POLITE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(確認してください|試していただけ|確認していただけ|教えていただけ|教えてください)")
+        .unwrap()
+});
+
+pub fn classify_has_question(text: &str) -> bool {
+    let tail: String = text
+        .lines()
+        .map(|l| l.trim_end())
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .take(3)
+        .collect::<Vec<_>>()
+        .join("\n");
+    ASK_QMARK.is_match(&tail) || ASK_POLITE.is_match(&tail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qmark_in_last_line_is_question() {
+        assert!(classify_has_question("結果です。\nこれで進めていいですか?"));
+    }
+
+    #[test]
+    fn fullwidth_qmark_is_question() {
+        assert!(classify_has_question("どちらにしましょうか？"));
+    }
+
+    #[test]
+    fn polite_request_is_question() {
+        assert!(classify_has_question("ビルドしました。\n動作を確認してください"));
+    }
+
+    #[test]
+    fn plain_done_report_is_not_question() {
+        assert!(!classify_has_question("実装完了しました。\nテストも通っています。"));
+    }
+
+    #[test]
+    fn dou_iu_is_not_question_without_qmark() {
+        assert!(!classify_has_question("どういう設計になっているか整理しました。"));
+    }
+
+    #[test]
+    fn qmark_outside_tail3_is_ignored() {
+        let text = "?\n\n\n(1) 最初に\n(2) 次に\n(3) 最後に完了しました。";
+        assert!(!classify_has_question(text));
+    }
+
+    #[test]
+    fn empty_text_is_not_question() {
+        assert!(!classify_has_question(""));
+    }
+}

--- a/ccfocus-logger/tests/event_serde.rs
+++ b/ccfocus-logger/tests/event_serde.rs
@@ -54,3 +54,40 @@ fn terminal_id_null_is_serialized_as_null_not_missing() {
     assert!(json.contains("\"git_branch\":null"));
     assert!(json.contains("\"claude_pid\":null"));
 }
+
+#[test]
+fn stop_serializes_has_question_when_true() {
+    let ev = Event {
+        ts: "2026-04-18T00:00:00.000Z".to_string(),
+        kind: EventKind::Stop {
+            session_id: "abc".to_string(),
+            has_question: Some(true),
+        },
+    };
+    let json = serde_json::to_string(&ev).unwrap();
+    assert!(json.contains("\"event\":\"stop\""));
+    assert!(json.contains("\"has_question\":true"));
+}
+
+#[test]
+fn stop_omits_has_question_when_none() {
+    let ev = Event {
+        ts: "2026-04-18T00:00:00.000Z".to_string(),
+        kind: EventKind::Stop {
+            session_id: "abc".to_string(),
+            has_question: None,
+        },
+    };
+    let json = serde_json::to_string(&ev).unwrap();
+    assert!(!json.contains("has_question"));
+}
+
+#[test]
+fn stop_deserializes_legacy_event_without_has_question() {
+    let raw = r#"{"ts":"2026-04-18T00:00:00.000Z","event":"stop","session_id":"abc"}"#;
+    let ev: Event = serde_json::from_str(raw).unwrap();
+    match ev.kind {
+        EventKind::Stop { has_question, .. } => assert!(has_question.is_none()),
+        _ => panic!("wrong variant"),
+    }
+}

--- a/ccfocus-logger/tests/log_writer.rs
+++ b/ccfocus-logger/tests/log_writer.rs
@@ -10,6 +10,7 @@ fn append_creates_file_with_single_line() {
         ts: "2026-04-16T00:00:00.000Z".to_string(),
         kind: EventKind::Stop {
             session_id: "abc".to_string(),
+            has_question: None,
         },
     };
     append_event_to(&path, &ev).unwrap();
@@ -27,6 +28,7 @@ fn append_two_events_produces_two_lines() {
             ts: "2026-04-16T00:00:00.000Z".to_string(),
             kind: EventKind::Stop {
                 session_id: sid.to_string(),
+                has_question: None,
             },
         };
         append_event_to(&path, &ev).unwrap();
@@ -43,6 +45,7 @@ fn append_creates_parent_dir_if_missing() {
         ts: "2026-04-16T00:00:00.000Z".to_string(),
         kind: EventKind::Stop {
             session_id: "abc".to_string(),
+            has_question: None,
         },
     };
     append_event_to(&path, &ev).unwrap();

--- a/ccfocus-logger/tests/stop_command.rs
+++ b/ccfocus-logger/tests/stop_command.rs
@@ -1,0 +1,36 @@
+use ccfocus_logger::event::EventKind;
+use ccfocus_logger::transcript::{classify_has_question, last_assistant_text};
+use std::io::Write;
+
+#[test]
+fn classify_from_sample_transcript_true() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("t.jsonl");
+    let mut f = std::fs::File::create(&path).unwrap();
+    writeln!(
+        f,
+        r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"次はどちらで進めますか?"}}]}}}}"#
+    )
+    .unwrap();
+    let text = last_assistant_text(&path).unwrap();
+    assert!(classify_has_question(&text));
+}
+
+#[test]
+fn stop_variant_accepts_has_question() {
+    let ev = EventKind::Stop {
+        session_id: "abc".to_string(),
+        has_question: Some(true),
+    };
+    match ev {
+        EventKind::Stop { has_question, .. } => assert_eq!(has_question, Some(true)),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn stop_payload_without_transcript_path_compiles_and_defaults() {
+    let raw = r#"{"session_id":"abc"}"#;
+    let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+    assert!(v.get("transcript_path").is_none());
+}

--- a/ccfocus/ccfocus/AppState.swift
+++ b/ccfocus/ccfocus/AppState.swift
@@ -93,7 +93,7 @@ final class AppState: ObservableObject {
                         }
                         if case .stop(let sid, _) = ev.kind,
                            let entry = registry.sessions[sid],
-                           entry.status == .done {
+                           (entry.status == .done || entry.status == .asking) {
                             onOpenPopover?()
                         }
                     }
@@ -121,7 +121,7 @@ final class AppState: ObservableObject {
     private func runLivenessCheck() {
         let terms = LivenessChecker.ghosttyTerminalIds()
         for (sid, e) in registry.sessions {
-            if [.idle, .running, .waitingInput, .done, .stale].contains(e.status) == false { continue }
+            if [.idle, .running, .asking, .waitingInput, .done, .stale].contains(e.status) == false { continue }
             if let pid = e.claudePid, let st = e.claudeStartTime, let cm = e.claudeComm {
                 if let cur = LivenessChecker.queryPs(pid: pid) {
                     if !LivenessChecker.verify(expected: (pid, st, cm), current: cur) {

--- a/ccfocus/ccfocus/AppState.swift
+++ b/ccfocus/ccfocus/AppState.swift
@@ -91,7 +91,7 @@ final class AppState: ObservableObject {
                            entry.status == .waitingInput {
                             onOpenPopover?()
                         }
-                        if case .stop(let sid) = ev.kind,
+                        if case .stop(let sid, _) = ev.kind,
                            let entry = registry.sessions[sid],
                            entry.status == .done {
                             onOpenPopover?()

--- a/ccfocus/ccfocus/Event.swift
+++ b/ccfocus/ccfocus/Event.swift
@@ -7,7 +7,7 @@ struct Event: Decodable {
     enum Kind {
         case sessionStart(SessionStart)
         case notification(Notification)
-        case stop(String)
+        case stop(String, Bool?)
         case preToolUse(PreToolUse)
         case userPromptSubmit(String)
     }
@@ -53,6 +53,7 @@ struct Event: Decodable {
         case ts
         case event
         case session_id
+        case has_question
     }
 
     init(from decoder: Decoder) throws {
@@ -67,7 +68,8 @@ struct Event: Decodable {
             self.kind = .notification(try single.decode(Notification.self))
         case "stop":
             let s = try c.decode(String.self, forKey: .session_id)
-            self.kind = .stop(s)
+            let hq = try c.decodeIfPresent(Bool.self, forKey: .has_question)
+            self.kind = .stop(s, hq)
         case "pre_tool_use":
             self.kind = .preToolUse(try single.decode(PreToolUse.self))
         case "user_prompt_submit":

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -155,6 +155,7 @@ struct MenuBarView: View {
         switch s {
         case .idle: return .gray
         case .running: return .green
+        case .asking: return .orange
         case .waitingInput: return .orange
         case .done: return .gray
         case .error: return .red

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -88,7 +88,7 @@ struct MenuBarView: View {
 
     private var isUnlinked: (SessionEntry) -> Bool {
         { s in
-            [.idle, .running, .waitingInput, .done].contains(s.status)
+            [.idle, .running, .asking, .waitingInput, .done].contains(s.status)
                 && state.effectiveTerminalId(for: s) == nil
         }
     }
@@ -126,6 +126,10 @@ struct MenuBarView: View {
             if s.status == .waitingInput, let msg = s.lastMessage {
                 Text(msg).font(.caption).foregroundStyle(.orange).padding(.leading, 16)
             }
+            if s.status == .asking {
+                Text(s.lastMessage ?? "asking")
+                    .font(.caption).foregroundStyle(.orange).padding(.leading, 16)
+            }
             if s.status == .done, s.doneNotified {
                 Text("done").font(.caption).foregroundStyle(.secondary).padding(.leading, 16)
             }
@@ -135,6 +139,7 @@ struct MenuBarView: View {
         }
         .padding(4)
         .background(
+            s.status == .asking ? Color.orange.opacity(0.1) :
             s.status == .waitingInput ? Color.orange.opacity(0.1) :
             s.status == .done && s.doneNotified ? Color.gray.opacity(0.1) :
             s.status == .idle ? Color.gray.opacity(0.1) :

--- a/ccfocus/ccfocus/SessionRegistry.swift
+++ b/ccfocus/ccfocus/SessionRegistry.swift
@@ -53,11 +53,12 @@ struct SessionRegistry {
                 e.lastEventTs = ev.ts
                 e.lastMessage = n.message
             }
-        case .stop(let sid, _):
+        case .stop(let sid, let hasQuestion):
             mutate(sid) { e in
-                e.status = SessionStatus.transitioned(current: e.status, event: .stop)
+                let kind: EventTransitionKind = (hasQuestion == true) ? .stopWithQuestion : .stop
+                e.status = SessionStatus.transitioned(current: e.status, event: kind)
                 e.lastEventTs = ev.ts
-                e.doneNotified = true
+                e.doneNotified = (hasQuestion != true)
             }
         case .preToolUse(let p):
             mutate(p.sessionId) { e in
@@ -110,7 +111,8 @@ extension SessionRegistry {
         for (sid, e) in sessions {
             guard let d = fmt.date(from: e.lastEventTs) else { continue }
             let age = now.timeIntervalSince(d)
-            if e.status == .idle || e.status == .running || e.status == .waitingInput || e.status == .done {
+            if e.status == .idle || e.status == .running || e.status == .asking
+                || e.status == .waitingInput || e.status == .done {
                 if age >= 30 * 60 { mutate(sid) { $0.status = .stale } }
             }
             if e.status == .stale && e.claudePid == nil && age >= 2.5 * 3600 {

--- a/ccfocus/ccfocus/SessionRegistry.swift
+++ b/ccfocus/ccfocus/SessionRegistry.swift
@@ -53,7 +53,7 @@ struct SessionRegistry {
                 e.lastEventTs = ev.ts
                 e.lastMessage = n.message
             }
-        case .stop(let sid):
+        case .stop(let sid, _):
             mutate(sid) { e in
                 e.status = SessionStatus.transitioned(current: e.status, event: .stop)
                 e.lastEventTs = ev.ts

--- a/ccfocus/ccfocus/SessionStatus.swift
+++ b/ccfocus/ccfocus/SessionStatus.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SessionStatus: String, Equatable {
     case idle
     case running
+    case asking
     case waitingInput = "waiting_input"
     case done
     case error
@@ -15,6 +16,7 @@ enum EventTransitionKind {
     case notification
     case preToolUse
     case stop
+    case stopWithQuestion
     case userPromptSubmit
 }
 
@@ -26,6 +28,7 @@ extension SessionStatus {
         case (_, .notification): return .waitingInput
         case (_, .preToolUse): return .running
         case (_, .stop): return .done
+        case (_, .stopWithQuestion): return .asking
         case (_, .userPromptSubmit): return .running
         }
     }

--- a/ccfocus/ccfocusTests/EventDecodingTests.swift
+++ b/ccfocus/ccfocusTests/EventDecodingTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ccfocus
+
+final class EventDecodingTests: XCTestCase {
+    func testStopWithHasQuestionTrue() throws {
+        let raw = #"{"ts":"2026-04-18T00:00:00.000Z","event":"stop","session_id":"abc","has_question":true}"#
+        let ev = try EventLogReader.decode(line: raw)
+        if case .stop(let sid, let hq) = ev.kind {
+            XCTAssertEqual(sid, "abc")
+            XCTAssertEqual(hq, true)
+        } else {
+            XCTFail("expected stop variant")
+        }
+    }
+
+    func testStopWithoutHasQuestion() throws {
+        let raw = #"{"ts":"2026-04-18T00:00:00.000Z","event":"stop","session_id":"abc"}"#
+        let ev = try EventLogReader.decode(line: raw)
+        if case .stop(_, let hq) = ev.kind {
+            XCTAssertNil(hq)
+        } else {
+            XCTFail("expected stop variant")
+        }
+    }
+}

--- a/ccfocus/ccfocusTests/EventLogReaderTests.swift
+++ b/ccfocus/ccfocusTests/EventLogReaderTests.swift
@@ -19,7 +19,7 @@ final class EventLogReaderTests: XCTestCase {
     func testParsesStop() throws {
         let line = #"{"ts":"2026-04-16T09:15:00.000Z","event":"stop","session_id":"abc"}"#
         let ev = try EventLogReader.decode(line: line)
-        if case .stop(let s) = ev.kind { XCTAssertEqual(s, "abc") } else { XCTFail() }
+        if case .stop(let s, _) = ev.kind { XCTAssertEqual(s, "abc") } else { XCTFail() }
     }
 
     func testSkipsBlankLines() throws {

--- a/ccfocus/ccfocusTests/SessionRegistryTests.swift
+++ b/ccfocus/ccfocusTests/SessionRegistryTests.swift
@@ -66,4 +66,27 @@ final class SessionRegistryTests: XCTestCase {
         let sorted = reg.sortedByLastEventDesc()
         XCTAssertEqual(sorted.map(\.sessionId), ["s1", "s2"])
     }
+
+    func testStopWithHasQuestionSetsAsking() throws {
+        var reg = SessionRegistry()
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:00.000Z","event":"session_start","session_id":"s","cwd":"/tmp"}"#))
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:01.000Z","event":"stop","session_id":"s","has_question":true}"#))
+        XCTAssertEqual(reg.sessions["s"]?.status, .asking)
+    }
+
+    func testStopWithoutHasQuestionSetsDone() throws {
+        var reg = SessionRegistry()
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:00.000Z","event":"session_start","session_id":"s","cwd":"/tmp"}"#))
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:01.000Z","event":"stop","session_id":"s"}"#))
+        XCTAssertEqual(reg.sessions["s"]?.status, .done)
+    }
+
+    func testAskingBecomesStaleAfter30Min() throws {
+        var reg = SessionRegistry()
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:00.000Z","event":"session_start","session_id":"s","cwd":"/tmp"}"#))
+        reg.apply(try EventLogReader.decode(line: #"{"ts":"2026-04-18T00:00:00.000Z","event":"stop","session_id":"s","has_question":true}"#))
+        let now = ISO8601DateFormatter().date(from: "2026-04-18T00:30:30Z")!
+        reg.applyStaleAfter(now)
+        XCTAssertEqual(reg.sessions["s"]?.status, .stale)
+    }
 }

--- a/ccfocus/ccfocusTests/SessionStatusTests.swift
+++ b/ccfocus/ccfocusTests/SessionStatusTests.swift
@@ -46,4 +46,28 @@ final class SessionStatusTests: XCTestCase {
     func testDeceasedStays() {
         XCTAssertEqual(SessionStatus.transitioned(current: .deceased, event: .notification), .deceased)
     }
+
+    func testStopWithQuestionTransitionsToAsking() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .running, event: .stopWithQuestion), .asking)
+    }
+
+    func testStopWithQuestionFromIdleToAsking() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .idle, event: .stopWithQuestion), .asking)
+    }
+
+    func testStopWithoutQuestionStillGoesToDone() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .running, event: .stop), .done)
+    }
+
+    func testDeceasedStaysOnStopWithQuestion() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .deceased, event: .stopWithQuestion), .deceased)
+    }
+
+    func testAskingTransitionsToRunningOnPreToolUse() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .asking, event: .preToolUse), .running)
+    }
+
+    func testAskingTransitionsToRunningOnUserPromptSubmit() {
+        XCTAssertEqual(SessionStatus.transitioned(current: .asking, event: .userPromptSubmit), .running)
+    }
 }


### PR DESCRIPTION
## What

Stop フック時点で assistant 最終発話を正規表現で質問判定し、新ステータス `.asking` を即時オレンジで表示する。done → waitingInput の 60 秒 idle fallback は維持。

設計: `tmp/doc/2026-04-18-asking-status-design.md`
計画: `tmp/doc/2026-04-18-asking-status-plan.md`