### PR TITLE
fix: inherit terminal_id on SessionStart re-fire and enable keys on menu bar click

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The uninstall preflight removes ccfocus entries from `~/.claude/settings.json`. 
 
 - `Tab` / `Shift+Tab` (panel focused): Cycle peek through sessions. Ghostty window is raised behind the panel without activating it.
 - `Esc` / global hotkey: Close the panel. Commits the last peek (activates that Ghostty pane) if peeked, otherwise restores the previously active app.
+- `Return` (panel focused, while peeking): Commit the peeked pane and close the panel (same as `Esc` while peeking; no-op otherwise).
 - `1`–`9`, `0` (panel focused): Jump directly to the Nth session.
 - Mouse click on `Cycle sessions` row: Advance peek by one step.
 

--- a/ccfocus-logger/src/commands/session_start.rs
+++ b/ccfocus-logger/src/commands/session_start.rs
@@ -7,6 +7,7 @@ use crate::log_writer::append_event_to;
 use crate::timestamp::now_iso8601;
 use anyhow::Result;
 use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::time::Duration;
 
@@ -16,31 +17,48 @@ pub struct HookPayload {
     pub cwd: String,
 }
 
+pub fn inherit_terminal_id(
+    claims: &HashMap<(u32, String), String>,
+    claude_pid: Option<u32>,
+    claude_start_time: Option<&str>,
+) -> Option<String> {
+    let (Some(pid), Some(start)) = (claude_pid, claude_start_time) else {
+        return None;
+    };
+    claims.get(&(pid, start.to_string())).cloned()
+}
+
 pub fn run() -> Result<()> {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf)?;
     let payload: HookPayload = serde_json::from_str(&buf)?;
-
-    let runner = RealRunner;
-    let claims = match events_dir() {
-        Ok(dir) => collect_live_claims(&runner, &dir),
-        Err(_) => std::collections::HashMap::new(),
-    };
-    let claimed: std::collections::HashSet<String> = claims.values().cloned().collect();
-    let terminal_id = find_terminal_id_with_retry(
-        &runner,
-        &payload.cwd,
-        &claimed,
-        5,
-        Duration::from_millis(100),
-    );
-    let git_branch = git_branch(&runner, &payload.cwd).unwrap_or(None);
 
     let claude_pid = std::env::var("CCFOCUS_CLAUDE_PID")
         .ok()
         .and_then(|s| s.parse().ok());
     let claude_start_time = std::env::var("CCFOCUS_CLAUDE_START").ok();
     let claude_comm = std::env::var("CCFOCUS_CLAUDE_COMM").ok();
+
+    let runner = RealRunner;
+    let claims = match events_dir() {
+        Ok(dir) => collect_live_claims(&runner, &dir),
+        Err(_) => HashMap::new(),
+    };
+    let inherited = inherit_terminal_id(&claims, claude_pid, claude_start_time.as_deref());
+    let terminal_id = match inherited {
+        Some(id) => Some(id),
+        None => {
+            let claimed: HashSet<String> = claims.values().cloned().collect();
+            find_terminal_id_with_retry(
+                &runner,
+                &payload.cwd,
+                &claimed,
+                5,
+                Duration::from_millis(100),
+            )
+        }
+    };
+    let git_branch = git_branch(&runner, &payload.cwd).unwrap_or(None);
 
     let ev = Event {
         ts: now_iso8601(),
@@ -75,5 +93,49 @@ mod tests {
         let json = r#"{"session_id":"abc","cwd":"/foo","hook_event_name":"SessionStart","extra":123}"#;
         let p: HookPayload = serde_json::from_str(json).unwrap();
         assert_eq!(p.session_id, "abc");
+    }
+
+    #[test]
+    fn inherit_returns_existing_terminal_for_matching_claim() {
+        let mut claims = std::collections::HashMap::new();
+        claims.insert((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T1".to_string());
+        let got = super::inherit_terminal_id(
+            &claims,
+            Some(111),
+            Some("Fri Apr 18 20:00:00 2026"),
+        );
+        assert_eq!(got, Some("T1".to_string()));
+    }
+
+    #[test]
+    fn inherit_returns_none_when_claim_missing() {
+        let mut claims = std::collections::HashMap::new();
+        claims.insert((222u32, "Fri Apr 18 21:00:00 2026".to_string()), "T2".to_string());
+        let got = super::inherit_terminal_id(
+            &claims,
+            Some(111),
+            Some("Fri Apr 18 20:00:00 2026"),
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn inherit_returns_none_when_pid_missing() {
+        let mut claims = std::collections::HashMap::new();
+        claims.insert((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T1".to_string());
+        let got = super::inherit_terminal_id(
+            &claims,
+            None,
+            Some("Fri Apr 18 20:00:00 2026"),
+        );
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn inherit_returns_none_when_start_missing() {
+        let mut claims = std::collections::HashMap::new();
+        claims.insert((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T1".to_string());
+        let got = super::inherit_terminal_id(&claims, Some(111), None);
+        assert_eq!(got, None);
     }
 }

--- a/ccfocus-logger/src/commands/session_start.rs
+++ b/ccfocus-logger/src/commands/session_start.rs
@@ -2,12 +2,11 @@ use crate::event::{Event, EventKind};
 use crate::ghostty::find_terminal_id_with_retry;
 use crate::git::{git_branch, RealRunner};
 use crate::log_path::{events_dir, log_file_for_now};
-use crate::log_reader::collect_live_claimed_terminal_ids;
+use crate::log_reader::collect_live_claims;
 use crate::log_writer::append_event_to;
 use crate::timestamp::now_iso8601;
 use anyhow::Result;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::io::Read;
 use std::time::Duration;
 
@@ -23,10 +22,11 @@ pub fn run() -> Result<()> {
     let payload: HookPayload = serde_json::from_str(&buf)?;
 
     let runner = RealRunner;
-    let claimed = match events_dir() {
-        Ok(dir) => collect_live_claimed_terminal_ids(&runner, &dir),
-        Err(_) => HashSet::new(),
+    let claims = match events_dir() {
+        Ok(dir) => collect_live_claims(&runner, &dir),
+        Err(_) => std::collections::HashMap::new(),
     };
+    let claimed: std::collections::HashSet<String> = claims.values().cloned().collect();
     let terminal_id = find_terminal_id_with_retry(
         &runner,
         &payload.cwd,

--- a/ccfocus-logger/src/log_reader.rs
+++ b/ccfocus-logger/src/log_reader.rs
@@ -1,6 +1,6 @@
 use crate::event::{Event, EventKind};
 use crate::git::CommandRunner;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use time::{Date, OffsetDateTime, UtcOffset};
 
@@ -13,10 +13,10 @@ struct Claim {
     claude_comm: String,
 }
 
-pub fn collect_live_claimed_terminal_ids(
+pub fn collect_live_claims(
     runner: &impl CommandRunner,
     dir: &Path,
-) -> HashSet<String> {
+) -> HashMap<(u32, String), String> {
     let dates = recent_dates();
     let mut latest: HashMap<(u32, String), Claim> = HashMap::new();
 
@@ -70,13 +70,13 @@ pub fn collect_live_claimed_terminal_ids(
         }
     }
 
-    let mut claimed = HashSet::new();
-    for claim in latest.values() {
-        if is_alive(runner, claim) {
-            claimed.insert(claim.terminal_id.clone());
+    let mut claims = HashMap::new();
+    for (key, claim) in latest {
+        if is_alive(runner, &claim) {
+            claims.insert(key, claim.terminal_id);
         }
     }
-    claimed
+    claims
 }
 
 fn is_alive(runner: &impl CommandRunner, claim: &Claim) -> bool {
@@ -165,14 +165,17 @@ mod tests {
     }
 
     #[test]
-    fn includes_terminal_when_ps_matches() {
+    fn returns_claim_when_ps_matches() {
         let tmp = TempDir::new().unwrap();
         let line = r#"{"ts":"2026-04-18T12:00:00.000Z","event":"session_start","session_id":"s1","terminal_id":"T1","cwd":"/foo","git_branch":null,"claude_pid":111,"claude_start_time":"Fri Apr 18 20:00:00 2026","claude_comm":"claude"}"#;
         write_today(tmp.path(), &format!("{line}\n"));
         let runner = PsRunner::new();
         runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert_eq!(claimed, HashSet::from(["T1".to_string()]));
+        let claims = collect_live_claims(&runner, tmp.path());
+        let expected: HashMap<(u32, String), String> = HashMap::from([
+            ((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T1".to_string()),
+        ]);
+        assert_eq!(claims, expected);
     }
 
     #[test]
@@ -182,8 +185,8 @@ mod tests {
         write_today(tmp.path(), &format!("{line}\n"));
         let runner = PsRunner::new();
         runner.set("111", Ok("111 Sat Apr 18 21:00:00 2026 claude\n".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert!(claimed.is_empty());
+        let claims = collect_live_claims(&runner, tmp.path());
+        assert!(claims.is_empty());
     }
 
     #[test]
@@ -193,8 +196,8 @@ mod tests {
         write_today(tmp.path(), &format!("{line}\n"));
         let runner = PsRunner::new();
         runner.set("111", Err("no such process".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert!(claimed.is_empty());
+        let claims = collect_live_claims(&runner, tmp.path());
+        assert!(claims.is_empty());
     }
 
     #[test]
@@ -205,8 +208,11 @@ mod tests {
         write_today(tmp.path(), &format!("{older}\n{newer}\n"));
         let runner = PsRunner::new();
         runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert_eq!(claimed, HashSet::from(["T_NEW".to_string()]));
+        let claims = collect_live_claims(&runner, tmp.path());
+        let expected: HashMap<(u32, String), String> = HashMap::from([
+            ((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T_NEW".to_string()),
+        ]);
+        assert_eq!(claims, expected);
     }
 
     #[test]
@@ -216,8 +222,8 @@ mod tests {
         write_today(tmp.path(), &format!("{line}\n"));
         let runner = PsRunner::new();
         runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert!(claimed.is_empty());
+        let claims = collect_live_claims(&runner, tmp.path());
+        assert!(claims.is_empty());
     }
 
     #[test]
@@ -228,14 +234,17 @@ mod tests {
         write_today(tmp.path(), &format!("{garbage}\n{valid}\n"));
         let runner = PsRunner::new();
         runner.set("111", Ok("111 Fri Apr 18 20:00:00 2026 claude\n".into()));
-        let claimed = collect_live_claimed_terminal_ids(&runner, tmp.path());
-        assert_eq!(claimed, HashSet::from(["T1".to_string()]));
+        let claims = collect_live_claims(&runner, tmp.path());
+        let expected: HashMap<(u32, String), String> = HashMap::from([
+            ((111u32, "Fri Apr 18 20:00:00 2026".to_string()), "T1".to_string()),
+        ]);
+        assert_eq!(claims, expected);
     }
 
     #[test]
     fn returns_empty_when_dir_missing() {
         let runner = PsRunner::new();
-        let claimed = collect_live_claimed_terminal_ids(&runner, Path::new("/nonexistent/ccfocus/path"));
-        assert!(claimed.is_empty());
+        let claims = collect_live_claims(&runner, Path::new("/nonexistent/ccfocus/path"));
+        assert!(claims.is_empty());
     }
 }

--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -189,6 +189,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             closePanel(reason: .userEscape)
             return true
         }
+        if event.keyCode == 36 {
+            guard state.lastPeekedTerminalId != nil else { return false }
+            closePanel(reason: .userEscape)
+            return true
+        }
         if event.keyCode == 48 {
             let forward = !event.modifierFlags.contains(.shift)
             peekOneStep(forward: forward)

--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -112,6 +112,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func togglePopover() {
         if panel.isVisible { closePanel(reason: .statusButtonToggle); return }
         showPanelUnfocused()
+        focusPanel()
     }
 
     private func handleHotkey() {


### PR DESCRIPTION
## What

- Logger now inherits the existing terminal_id on SessionStart re-fire (Claude Code `/clear`, `/compact`), closing #23.
- Tab-cycle panel gains Return to commit the peeked pane (mirrors Escape while peeking; no-op otherwise).
- Menu bar icon click now focuses the panel so Tab / Return / Escape / number keys work.

## Test plan

- [x] `cargo test -p ccfocus-logger` and `cargo clippy -p ccfocus-logger -- -D warnings` green
- [x] `xcodebuild ... scheme ccfocusTests test` green
- [x] Manual: `/clear` re-fire → new session linked, jsonl carries inherited terminal_id
- [x] Manual: Tab peek → Return commits peek and closes panel; Return outside peek is no-op
- [x] Manual: menu bar click opens panel as key window; Tab / Return / Escape / number keys respond

## Follow-ups

- Dedicated `PanelCloseReason.userReturn` (observability; spec decided against it in this PR, reviewer noted as future cleanup).
- End-to-end test for `session_start::run()` wiring (unit coverage on `inherit_terminal_id` + `collect_live_claims` only).
- Keypad Enter (keyCode 76) support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)