### PR TITLE
Polish panel layout: dynamic resize, peek commit parity, stable width

### DIFF
--- a/ccfocus/ccfocus/AppState.swift
+++ b/ccfocus/ccfocus/AppState.swift
@@ -196,6 +196,10 @@ final class AppState: ObservableObject {
 
     func commitLastPeek() {
         guard let tid = lastPeekedTerminalId else { return }
+        if let sid = lastPeekedSessionId {
+            clearMessage(sid)
+            clearDoneNotified(sid)
+        }
         GhosttyFocus.focus(terminalId: tid)
     }
 

--- a/ccfocus/ccfocus/BranchTextTruncator.swift
+++ b/ccfocus/ccfocus/BranchTextTruncator.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum BranchTextTruncator {
+    static let defaultTotal = 20
+    static let ellipsis = ".."
+
+    static func truncate(_ value: String, total: Int = defaultTotal) -> String {
+        guard total > ellipsis.count else { return value }
+        guard value.count > total else { return value }
+        let keep = total - ellipsis.count
+        let headLen = keep - keep / 2
+        let tailLen = keep / 2
+        let head = value.prefix(headLen)
+        let tail = value.suffix(tailLen)
+        return "\(head)\(ellipsis)\(tail)"
+    }
+}

--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -54,6 +54,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         hostingView = KeyHandlingHostingView(rootView: menuView)
         hostingView.onKeyDown = { [weak self] event in self?.handleKeyDown(event) ?? false }
+        hostingView.onDidLayout = { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.applyContentSize(self.hostingView.fittingSize)
+            }
+        }
 
         let panelRect = NSRect(x: 0, y: 0, width: 340, height: 10)
         panel = KeyablePanel(contentRect: panelRect,
@@ -125,21 +131,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showPanelUnfocused() {
-        guard let button = statusItem.button, let window = button.window else { return }
+        guard let button = statusItem.button, let buttonWindow = button.window else { return }
         if panel.isVisible { return }
+        hostingView.layoutSubtreeIfNeeded()
         let fitting = hostingView.fittingSize
-        panel.setContentSize(fitting)
-        hostingView.frame = NSRect(origin: .zero, size: fitting)
-        let buttonRectOnScreen = window.convertToScreen(button.frame)
-        let origin = NSPoint(x: buttonRectOnScreen.midX - panel.frame.width / 2,
-                             y: buttonRectOnScreen.minY - panel.frame.height)
-        panel.setFrameOrigin(origin)
+        positionPanel(size: fitting, button: button, buttonWindow: buttonWindow)
         panel.orderFront(nil)
         hostingView.wantsKeyboardFocus = false
         state.capturePreviousFrontmostApp()
         stateMachine.markOpenedUnfocused()
         observeKeyWindowNotifications()
         installClickOutsideMonitorIfNeeded()
+    }
+
+    private func applyContentSize(_ size: CGSize) {
+        guard panel.isVisible else { return }
+        guard size.width > 0, size.height > 0 else { return }
+        guard let button = statusItem.button, let buttonWindow = button.window else { return }
+        positionPanel(size: size, button: button, buttonWindow: buttonWindow)
+    }
+
+    private func positionPanel(size: CGSize, button: NSStatusBarButton, buttonWindow: NSWindow) {
+        panel.setContentSize(size)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        let buttonRectOnScreen = buttonWindow.convertToScreen(button.frame)
+        let origin = NSPoint(x: buttonRectOnScreen.midX - panel.frame.width / 2,
+                             y: buttonRectOnScreen.minY - panel.frame.height)
+        panel.setFrameOrigin(origin)
     }
 
     private func installClickOutsideMonitorIfNeeded() {

--- a/ccfocus/ccfocus/KeyHandlingHostingView.swift
+++ b/ccfocus/ccfocus/KeyHandlingHostingView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 final class KeyHandlingHostingView<Content: View>: NSHostingView<Content> {
     var onKeyDown: ((NSEvent) -> Bool)?
+    var onDidLayout: (() -> Void)?
     var wantsKeyboardFocus: Bool = false
 
     override var acceptsFirstResponder: Bool { wantsKeyboardFocus }
@@ -13,5 +14,10 @@ final class KeyHandlingHostingView<Content: View>: NSHostingView<Content> {
             return
         }
         super.keyDown(with: event)
+    }
+
+    override func layout() {
+        super.layout()
+        onDidLayout?()
     }
 }

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -94,7 +94,7 @@ struct MenuBarView: View {
             .onTapGesture { NSApp.terminate(nil) }
         }
         .padding(8)
-        .frame(minWidth: 320)
+        .frame(width: 320)
     }
 
     private var isUnlinked: (SessionEntry) -> Bool {
@@ -147,7 +147,7 @@ struct MenuBarView: View {
                 .fontWeight(session.status == .waitingInput ? .semibold : .regular)
                 .lineLimit(1)
             if let branch = session.gitBranch {
-                Text("[\(branch)]")
+                Text("[\(BranchTextTruncator.truncate(branch))]")
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/ccfocus/ccfocusTests/AppStateCycleTests.swift
+++ b/ccfocus/ccfocusTests/AppStateCycleTests.swift
@@ -96,4 +96,25 @@ final class AppStateCycleTests: XCTestCase {
         XCTAssertNil(state.lastPeekedSessionId)
         XCTAssertNil(state.lastPeekedTerminalId)
     }
+
+    func testCommitLastPeekClearsMessageAndDoneNotified() {
+        let state = AppState()
+        seed(state, entries: [("a", "t1", "2026-04-22T00:00:01Z")])
+        state.registry.sessions["a"]?.lastMessage = "pending"
+        state.registry.sessions["a"]?.doneNotified = true
+        _ = state.cycleSessionsOneStep(forward: true)
+        state.commitLastPeek()
+        XCTAssertNil(state.registry.sessions["a"]?.lastMessage)
+        XCTAssertEqual(state.registry.sessions["a"]?.doneNotified, false)
+    }
+
+    func testCommitLastPeekWithoutPeekDoesNothing() {
+        let state = AppState()
+        seed(state, entries: [("a", "t1", "2026-04-22T00:00:01Z")])
+        state.registry.sessions["a"]?.lastMessage = "pending"
+        state.registry.sessions["a"]?.doneNotified = true
+        state.commitLastPeek()
+        XCTAssertEqual(state.registry.sessions["a"]?.lastMessage, "pending")
+        XCTAssertEqual(state.registry.sessions["a"]?.doneNotified, true)
+    }
 }

--- a/ccfocus/ccfocusTests/BranchTextTruncatorTests.swift
+++ b/ccfocus/ccfocusTests/BranchTextTruncatorTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import ccfocus
+
+final class BranchTextTruncatorTests: XCTestCase {
+    func testShortStringIsUnchanged() {
+        XCTAssertEqual(BranchTextTruncator.truncate("main"), "main")
+    }
+
+    func testExactlyAtLimitIsUnchanged() {
+        let s = String(repeating: "a", count: BranchTextTruncator.defaultTotal)
+        XCTAssertEqual(BranchTextTruncator.truncate(s), s)
+    }
+
+    func testLongStringCollapsesToDefaultTotal() {
+        let input = "po/issue-23-refire-and-return-close"
+        let out = BranchTextTruncator.truncate(input)
+        XCTAssertEqual(out.count, BranchTextTruncator.defaultTotal)
+        XCTAssertTrue(out.contains(".."))
+        XCTAssertTrue(out.hasPrefix("po/issue-"))
+        XCTAssertTrue(out.hasSuffix("urn-close"))
+    }
+
+    func testOddKeepSplitsHeadLarger() {
+        let input = "abcdefghijklmnopqrstuvwxyz"
+        let out = BranchTextTruncator.truncate(input, total: 11)
+        XCTAssertEqual(out.count, 11)
+        XCTAssertEqual(out, "abcde..wxyz")
+    }
+
+    func testTotalSmallerThanEllipsisReturnsOriginal() {
+        XCTAssertEqual(BranchTextTruncator.truncate("abcdef", total: 1), "abcdef")
+    }
+}


### PR DESCRIPTION
## Summary
- NSHostingView の layout() をフックして SwiftUI の再レイアウト毎に fittingSize でパネルをリサイズ。deceased 展開や 2 行目ラベルの追加で上下 padding が潰れていた問題を解消。
- Tab 周回中の Return / ESC によるコミットで、ピーク対象行の lastMessage と doneNotified をクリア。クリック時と視覚挙動が一致。
- ブランチラベルを中央 .. 省略で 20 字に収め、パネル外形を .frame(width: 320) で固定。ブランチ長によって横幅がゆらぐ違和感を解消。

## Test plan
- [x] xcodebuild test (ccfocusTests 全 95 件パス、うち AppStateCycleTests に 2 件、BranchTextTruncatorTests に 5 件追加)
- [x] Debug ビルドを起動し、deceased 展開時の余白保持を目視確認
- [x] Tab ピーク中の Return/ESC で再オープン時にオレンジ背景・2 行目ラベルが消えることを確認
- [x] 長いブランチ名の省略と横幅固定を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)