### PR TITLE
chore: use --merge in releasing skill

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -14,11 +14,11 @@ Create a pull request. Skip this step if one already exists for the current bran
 
 ### 2. Enable automerge
 
-Mark the PR as ready if it is a draft, then enable automerge with squash.
+Mark the PR as ready if it is a draft, then enable automerge. This repo only allows merge commits (squash is disabled), so use `--merge`.
 
 ```bash
 gh pr ready
-gh pr merge --auto --squash
+gh pr merge --auto --merge
 ```
 
 ### 3. Wait for merge


### PR DESCRIPTION
## Summary
- /releasing skill の automerge 手順をリポジトリ設定(squash 無効 / merge のみ許可)に合わせて `--merge` に修正。
- 先日の PR #27 リリース時に `--squash` で弾かれたフォールバック体験を踏まえた、プロジェクトローカル前提の決め打ち。

## Test plan
- [x] docs-only 変更のため automated test なし
- [x] 本 PR 自身の automerge 成立を /releasing 新手順で確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)