### PR TITLE
feat: suppress auto-close when panel opened by user

### DIFF
--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -26,11 +26,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let settingsWindowController = SettingsWindowController()
     private var keyObservers: [NSObjectProtocol] = []
     private var clickOutsideMonitor: Any?
+    private var panelUserOwned: Bool = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         registerLoginItemIfNeeded()
         state.bootstrap()
-        state.onOpenPopover = { [weak self] in self?.showPanelUnfocused() }
+        state.onOpenPopover = { [weak self] in self?.showPanelUnfocused(automatic: true) }
         state.onClosePopover = { [weak self] in
             guard let self else { return }
             self.closePanel(reason: .attentionCleared)
@@ -117,7 +118,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func togglePopover() {
         if panel.isVisible { closePanel(reason: .statusButtonToggle); return }
-        showPanelUnfocused()
+        showPanelUnfocused(automatic: false)
         focusPanel()
     }
 
@@ -125,12 +126,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if panel.isVisible {
             if panel.isKeyWindow { closePanel(reason: .userHotkey) } else { focusPanel() }
         } else {
-            showPanelUnfocused()
+            showPanelUnfocused(automatic: false)
             focusPanel()
         }
     }
 
-    private func showPanelUnfocused() {
+    private func showPanelUnfocused(automatic: Bool) {
         guard let button = statusItem.button, let buttonWindow = button.window else { return }
         if panel.isVisible { return }
         hostingView.layoutSubtreeIfNeeded()
@@ -140,6 +141,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hostingView.wantsKeyboardFocus = false
         state.capturePreviousFrontmostApp()
         stateMachine.markOpenedUnfocused()
+        panelUserOwned = !automatic
         observeKeyWindowNotifications()
         installClickOutsideMonitorIfNeeded()
     }
@@ -238,7 +240,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         keyObservers.removeAll()
         let center = NotificationCenter.default
         let becameKey = center.addObserver(forName: NSWindow.didBecomeKeyNotification, object: panel, queue: .main) { [weak self] _ in
-            Task { @MainActor in self?.stateMachine.markBecameKey() }
+            Task { @MainActor in
+                self?.stateMachine.markBecameKey()
+                self?.panelUserOwned = true
+            }
         }
         let resignedKey = center.addObserver(forName: NSWindow.didResignKeyNotification, object: panel, queue: .main) { [weak self] _ in
             Task { @MainActor in self?.stateMachine.markResignedKey() }
@@ -257,13 +262,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let decision = PanelCloseDecision.decide(
             reason: reason,
             isPeekActive: state.lastPeekedTerminalId != nil,
-            isCcfocusFrontmost: isFrontmost
+            isCcfocusFrontmost: isFrontmost,
+            panelUserOwned: panelUserOwned
         )
         guard decision.shouldClose else { return }
         if decision.shouldCommit { state.commitLastPeek() }
         if decision.shouldRestoreFrontmost { state.restorePreviousFrontmostApp() }
         state.resetCycleState()
         panel.close()
+        panelUserOwned = false
         removeClickOutsideMonitor()
     }
 

--- a/ccfocus/ccfocus/PanelCloseDecision.swift
+++ b/ccfocus/ccfocus/PanelCloseDecision.swift
@@ -15,7 +15,10 @@ struct PanelCloseDecision {
     let shouldCommit: Bool
     let shouldRestoreFrontmost: Bool
 
-    static func decide(reason: PanelCloseReason, isPeekActive: Bool, isCcfocusFrontmost: Bool) -> PanelCloseDecision {
+    static func decide(reason: PanelCloseReason, isPeekActive: Bool, isCcfocusFrontmost: Bool, panelUserOwned: Bool) -> PanelCloseDecision {
+        if reason == .attentionCleared && panelUserOwned {
+            return PanelCloseDecision(shouldClose: false, shouldCommit: false, shouldRestoreFrontmost: false)
+        }
         if reason == .attentionCleared && isPeekActive {
             return PanelCloseDecision(shouldClose: false, shouldCommit: false, shouldRestoreFrontmost: false)
         }

--- a/ccfocus/ccfocusTests/PanelCloseDecisionTests.swift
+++ b/ccfocus/ccfocusTests/PanelCloseDecisionTests.swift
@@ -3,70 +3,84 @@ import XCTest
 
 final class PanelCloseDecisionTests: XCTestCase {
     func testAttentionClearedDuringPeekSuppressesClose() {
-        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: true, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: true, isCcfocusFrontmost: true, panelUserOwned: false)
         XCTAssertFalse(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
     func testAttentionClearedNoPeekAndCcfocusFrontmostRestores() {
-        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: false, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: false)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertTrue(d.shouldRestoreFrontmost)
     }
 
     func testAttentionClearedNoPeekAndCcfocusNotFrontmostDoesNotRestore() {
-        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: false, isCcfocusFrontmost: false)
+        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: false, isCcfocusFrontmost: false, panelUserOwned: false)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
+    func testAttentionClearedWhenUserOwnedSuppressesClose() {
+        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: true)
+        XCTAssertFalse(d.shouldClose)
+        XCTAssertFalse(d.shouldCommit)
+        XCTAssertFalse(d.shouldRestoreFrontmost)
+    }
+
+    func testAttentionClearedWhenUserOwnedAndPeekActiveSuppressesClose() {
+        let d = PanelCloseDecision.decide(reason: .attentionCleared, isPeekActive: true, isCcfocusFrontmost: true, panelUserOwned: true)
+        XCTAssertFalse(d.shouldClose)
+        XCTAssertFalse(d.shouldCommit)
+        XCTAssertFalse(d.shouldRestoreFrontmost)
+    }
+
     func testUserEscapeWithPeekCommits() {
-        let d = PanelCloseDecision.decide(reason: .userEscape, isPeekActive: true, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .userEscape, isPeekActive: true, isCcfocusFrontmost: true, panelUserOwned: true)
         XCTAssertTrue(d.shouldClose)
         XCTAssertTrue(d.shouldCommit)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
     func testUserEscapeNoPeekAndCcfocusFrontmostRestores() {
-        let d = PanelCloseDecision.decide(reason: .userEscape, isPeekActive: false, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .userEscape, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: true)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertTrue(d.shouldRestoreFrontmost)
     }
 
     func testUserHotkeyNoPeekAndCcfocusFrontmostRestores() {
-        let d = PanelCloseDecision.decide(reason: .userHotkey, isPeekActive: false, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .userHotkey, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: true)
         XCTAssertTrue(d.shouldClose)
         XCTAssertTrue(d.shouldRestoreFrontmost)
     }
 
     func testCommittedViaRowNeverRestores() {
-        let d = PanelCloseDecision.decide(reason: .committedViaRow, isPeekActive: false, isCcfocusFrontmost: true)
+        let d = PanelCloseDecision.decide(reason: .committedViaRow, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: false)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
     func testClickOutsideWithPeekDoesNotCommit() {
-        let d = PanelCloseDecision.decide(reason: .clickOutside, isPeekActive: true, isCcfocusFrontmost: false)
+        let d = PanelCloseDecision.decide(reason: .clickOutside, isPeekActive: true, isCcfocusFrontmost: false, panelUserOwned: true)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldCommit)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
     func testClickOutsideNoPeekNeverRestores() {
-        let d = PanelCloseDecision.decide(reason: .clickOutside, isPeekActive: false, isCcfocusFrontmost: false)
+        let d = PanelCloseDecision.decide(reason: .clickOutside, isPeekActive: false, isCcfocusFrontmost: false, panelUserOwned: false)
         XCTAssertTrue(d.shouldClose)
         XCTAssertFalse(d.shouldRestoreFrontmost)
     }
 
     func testStatusButtonToggleBehavesLikeUserEscape() {
         XCTAssertEqual(
-            PanelCloseDecision.decide(reason: .statusButtonToggle, isPeekActive: false, isCcfocusFrontmost: true).shouldRestoreFrontmost,
-            PanelCloseDecision.decide(reason: .userEscape, isPeekActive: false, isCcfocusFrontmost: true).shouldRestoreFrontmost
+            PanelCloseDecision.decide(reason: .statusButtonToggle, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: true).shouldRestoreFrontmost,
+            PanelCloseDecision.decide(reason: .userEscape, isPeekActive: false, isCcfocusFrontmost: true, panelUserOwned: true).shouldRestoreFrontmost
         )
     }
 }

--- a/docs/superpowers/specs/2026-04-23-auto-close-respects-open-source-design.md
+++ b/docs/superpowers/specs/2026-04-23-auto-close-respects-open-source-design.md
@@ -1,0 +1,90 @@
+# Auto-close respects open source
+
+## 背景
+
+ccfocus のパネルは `registry.attentionCount` が `>0 → 0` に遷移したとき自動で閉じる (`PopoverAutoCloseGate` → `onClosePopover` → `closePanel(reason: .attentionCleared)`)。
+
+現状はこの自動クローズが「パネルをどう開いたか」に関係なく発火する。ユーザがステータスバークリックやグローバルホットキーで能動的に開いたパネルでも、attention が 0 になった瞬間に閉じられてしまう。ユーザが TAB サイクル中などに意図せずパネルが消える不具合相当の挙動。
+
+## 要件
+
+- 自動オープン (新しい attention イベントによるオープン) 起源のパネルに限り、`attentionCleared` での自動クローズを許可する。
+- ユーザ操作で開いた、あるいはユーザが事後的に触ったパネルは `attentionCleared` では閉じない。
+- 既存の peek 中は閉じないガード (`isPeekActive`) は維持する。
+- 既存のその他クローズ経路 (Escape/ホットキー/クリックアウト/コミット/ステータスバートグル) の挙動は変えない。
+
+## 設計
+
+### 状態
+
+`AppDelegate` にフラグ `panelUserOwned: Bool` を追加する。
+
+- 初期値
+  - 自動オープン経路 (`state.onOpenPopover` → `showPanelUnfocused`): `false`
+  - ステータスバークリック (`togglePopover`) / グローバルホットキー (`handleHotkey` で不可視からのオープン): `true`
+- 昇格
+  - パネルの `didBecomeKeyNotification` 発火時に `true` に設定する。これにより自動オープン後にユーザがホットキーやクリックで key window 化した場合に user-owned へ昇格する。
+- 降格
+  - しない。`resignedKey` では降格しない (一度ユーザが触ったパネルは、非フォーカスになっても user-owned のまま扱う)。
+- リセット
+  - `closePanel` が実際に close を実行したタイミングで `false` に戻す。
+
+### 判定
+
+`PanelCloseDecision.decide` に `panelUserOwned: Bool` 引数を追加する。
+
+- `reason == .attentionCleared && panelUserOwned` のケースを最上部のガードに追加 (既存の peek ガードと同じ構造)。`shouldClose: false` を返す。
+- それ以外の挙動は不変。
+
+```swift
+static func decide(
+    reason: PanelCloseReason,
+    isPeekActive: Bool,
+    isCcfocusFrontmost: Bool,
+    panelUserOwned: Bool
+) -> PanelCloseDecision {
+    if reason == .attentionCleared && panelUserOwned {
+        return PanelCloseDecision(shouldClose: false, shouldCommit: false, shouldRestoreFrontmost: false)
+    }
+    if reason == .attentionCleared && isPeekActive {
+        return PanelCloseDecision(shouldClose: false, shouldCommit: false, shouldRestoreFrontmost: false)
+    }
+    // 以降は既存ロジック
+}
+```
+
+### 開閉経路への組み込み
+
+`showPanelUnfocused(automatic: Bool)` として明示引数化し、内部で `panelUserOwned = !automatic` を設定する。
+
+- 呼び出し側
+  - `state.onOpenPopover`: `showPanelUnfocused(automatic: true)`
+  - `togglePopover` (不可視からのオープン): `showPanelUnfocused(automatic: false)`
+  - `handleHotkey` (不可視からのオープン): `showPanelUnfocused(automatic: false)`
+- 昇格
+  - `didBecomeKeyNotification` observer で `panelUserOwned = true` を設定する (既に `true` でも冪等)
+- リセット
+  - `closePanel` の `decision.shouldClose` が真で `panel.close()` を実行した直後に `panelUserOwned = false`
+
+## テスト
+
+`PanelCloseDecisionTests` を更新・追加する。
+
+- 追加: `attentionCleared + panelUserOwned=true + peek なし` → `shouldClose=false`
+- 追加: `attentionCleared + panelUserOwned=false + peek なし` → `shouldClose=true`
+- 追加: `attentionCleared + panelUserOwned=true + peek あり` → `shouldClose=false` (どちらのガードでも閉じない)
+- 既存の全ケースに `panelUserOwned: false` を明示的に渡す形で引数を更新する。
+
+`PopoverAutoCloseGate` は責務を変えないので変更しない。
+
+## スコープ外
+
+- 手動オープン中に attention が発生 → 既に `panel.isVisible` ガードで no-op、フラグも変化しない。挙動は従来どおり。
+- 自動オープン→自動クローズ後、続けて別の attention が発生したケース: 新しいオープンから再スタート。
+- `PopoverAutoCloseGate` の内部挙動。
+
+## 影響範囲
+
+- `ccfocus/ccfocus/PanelCloseDecision.swift`
+- `ccfocus/ccfocus/CcfocusApp.swift`
+- `ccfocus/ccfocusTests/PanelCloseDecisionTests.swift`


### PR DESCRIPTION
## Summary
- パネルの自動クローズ (attention が 0 になったときの `.attentionCleared` による close) を、自動オープン起源のパネルに限定する
- ステータスバークリック/グローバルホットキーで開いた、あるいは自動オープン後にユーザが key window 化したパネルは `attentionCleared` で閉じない
- `PanelCloseDecision.decide` に `panelUserOwned` を追加し、`AppDelegate` がオープン経路 + `didBecomeKeyNotification` で管理する

詳細仕様: `docs/superpowers/specs/2026-04-23-auto-close-respects-open-source-design.md`

## Test plan
- [x] `xcodebuild test` で全 95 テスト pass
- [x] ローカルビルド + 起動で確認
- [ ] 実セッションで自動オープン → attention 0 で閉じること
- [ ] ステータスバークリックで開いたパネルが attention 0 で残ること
- [ ] グローバルホットキーで開いたパネルが attention 0 で残ること
- [ ] 自動オープン → ホットキー focus → attention 0 で残ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)