### PR TITLE
feat: add global Cycle hotkey with center-screen HUD

### DIFF
--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -23,6 +23,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let state = AppState()
     private var stateMachine = PopoverStateMachine()
     private let hotkeyController = HotkeyController()
+    private let globalCycleController = GlobalCycleController()
+    private let cycleHUDController = CycleHUDController()
     private let settingsWindowController = SettingsWindowController()
     private var keyObservers: [NSObjectProtocol] = []
     private var clickOutsideMonitor: Any?
@@ -88,7 +90,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         effectView.addSubview(hostingView)
         panel.contentView = effectView
 
+        cycleHUDController.prepare()
         hotkeyController.onToggleFocus = { [weak self] in self?.handleHotkey() }
+        hotkeyController.onCycleNext = { [weak self] in self?.handleGlobalCycle() }
         hotkeyController.start()
 
         setupMainMenu()
@@ -129,6 +133,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             showPanelUnfocused(automatic: false)
             focusPanel()
         }
+    }
+
+    private func handleGlobalCycle() {
+        guard let entry = globalCycleController.cycleNext(state: state) else { return }
+        cycleHUDController.show(session: entry)
     }
 
     private func showPanelUnfocused(automatic: Bool) {

--- a/ccfocus/ccfocus/CycleHUDController.swift
+++ b/ccfocus/ccfocus/CycleHUDController.swift
@@ -1,0 +1,106 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CycleHUDController {
+    private var panel: NSPanel?
+    private var hostingView: NSHostingView<CycleHUDView>?
+    private var dismissWorkItem: DispatchWorkItem?
+    private let displayDuration: TimeInterval = 1.0
+    private let fadeDuration: TimeInterval = 0.15
+
+    func prepare() {
+        guard panel == nil else { return }
+        let initial = CycleHUDView(model: .empty)
+        let hosting = NSHostingView(rootView: initial)
+        hosting.layer?.cornerRadius = 16
+        hosting.layer?.masksToBounds = true
+
+        let effect = NSVisualEffectView()
+        effect.material = .hudWindow
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = 16
+        effect.layer?.masksToBounds = true
+
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        effect.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: effect.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: effect.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: effect.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: effect.bottomAnchor)
+        ])
+
+        let p = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 80),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        p.level = .statusBar
+        p.isFloatingPanel = true
+        p.hidesOnDeactivate = false
+        p.becomesKeyOnlyIfNeeded = true
+        p.ignoresMouseEvents = true
+        p.backgroundColor = .clear
+        p.isOpaque = false
+        p.hasShadow = true
+        p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+        p.contentView = effect
+        p.alphaValue = 0
+        self.panel = p
+        self.hostingView = hosting
+    }
+
+    func show(session: SessionEntry) {
+        prepare()
+        guard let panel, let hostingView else { return }
+        let model = CycleHUDModel(
+            projectName: (session.cwd as NSString).lastPathComponent,
+            statusColor: session.status.displayColor
+        )
+        hostingView.rootView = CycleHUDView(model: model)
+        hostingView.layoutSubtreeIfNeeded()
+        let size = hostingView.fittingSize
+        panel.setContentSize(size)
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(mouse) }) ?? NSScreen.main
+        let frame = screen?.visibleFrame ?? .zero
+        panel.setFrameOrigin(NSPoint(
+            x: frame.midX - size.width / 2,
+            y: frame.midY - size.height / 2
+        ))
+        if !panel.isVisible {
+            panel.alphaValue = 0
+            panel.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = fadeDuration
+                panel.animator().alphaValue = 1.0
+            }
+        } else {
+            panel.alphaValue = 1.0
+        }
+        scheduleDismiss()
+    }
+
+    private func scheduleDismiss() {
+        dismissWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            Task { @MainActor in self?.fadeOut() }
+        }
+        dismissWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + displayDuration, execute: item)
+    }
+
+    private func fadeOut() {
+        guard let panel, panel.isVisible else { return }
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = fadeDuration
+            panel.animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            self?.panel?.orderOut(nil)
+        }
+    }
+}

--- a/ccfocus/ccfocus/CycleHUDController.swift
+++ b/ccfocus/ccfocus/CycleHUDController.swift
@@ -100,7 +100,7 @@ final class CycleHUDController {
             ctx.duration = fadeDuration
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
-            self?.panel?.orderOut(nil)
+            Task { @MainActor in self?.panel?.orderOut(nil) }
         }
     }
 }

--- a/ccfocus/ccfocus/CycleHUDView.swift
+++ b/ccfocus/ccfocus/CycleHUDView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct CycleHUDModel: Equatable {
+    var projectName: String
+    var statusColor: Color
+
+    static let empty = CycleHUDModel(projectName: "", statusColor: .clear)
+}
+
+struct CycleHUDView: View {
+    let model: CycleHUDModel
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Circle()
+                .fill(model.statusColor)
+                .frame(width: 28, height: 28)
+            Text(model.projectName)
+                .font(.system(size: 44, weight: .semibold))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 18)
+    }
+}

--- a/ccfocus/ccfocus/GlobalCycleController.swift
+++ b/ccfocus/ccfocus/GlobalCycleController.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+protocol TerminalFocusing {
+    func focus(terminalId: String)
+}
+
+struct GhosttyTerminalFocus: TerminalFocusing {
+    func focus(terminalId: String) {
+        GhosttyFocus.focus(terminalId: terminalId)
+    }
+}
+
+@MainActor
+final class GlobalCycleController {
+    private(set) var anchorSessionId: String?
+    private let focuser: TerminalFocusing
+
+    init(focuser: TerminalFocusing = GhosttyTerminalFocus()) {
+        self.focuser = focuser
+    }
+
+    func cycleNext(state: AppState) -> SessionEntry? {
+        let candidates = state.registry.sortedByLastEventDesc()
+            .filter { $0.status != .deceased }
+            .filter { state.effectiveTerminalId(for: $0) != nil }
+        guard !candidates.isEmpty else {
+            anchorSessionId = nil
+            return nil
+        }
+        let nextIndex: Int
+        if let anchor = anchorSessionId,
+           let idx = candidates.firstIndex(where: { $0.sessionId == anchor }) {
+            nextIndex = (idx + 1) % candidates.count
+        } else {
+            nextIndex = 0
+        }
+        let target = candidates[nextIndex]
+        anchorSessionId = target.sessionId
+        if let tid = state.effectiveTerminalId(for: target) {
+            focuser.focus(terminalId: tid)
+        }
+        return target
+    }
+
+    func reset() {
+        anchorSessionId = nil
+    }
+}

--- a/ccfocus/ccfocus/HotkeyController.swift
+++ b/ccfocus/ccfocus/HotkeyController.swift
@@ -4,10 +4,14 @@ import KeyboardShortcuts
 @MainActor
 final class HotkeyController {
     var onToggleFocus: (() -> Void)?
+    var onCycleNext: (() -> Void)?
 
     func start() {
         KeyboardShortcuts.onKeyDown(for: .toggleFocus) { [weak self] in
             self?.onToggleFocus?()
+        }
+        KeyboardShortcuts.onKeyDown(for: .cycleNext) { [weak self] in
+            self?.onCycleNext?()
         }
     }
 }

--- a/ccfocus/ccfocus/KeyboardShortcutsNames.swift
+++ b/ccfocus/ccfocus/KeyboardShortcutsNames.swift
@@ -5,4 +5,5 @@ extension KeyboardShortcuts.Name {
         "toggleFocus",
         default: .init(.f, modifiers: [.command, .option])
     )
+    static let cycleNext = Self("cycleNext")
 }

--- a/ccfocus/ccfocus/MenuBarView.swift
+++ b/ccfocus/ccfocus/MenuBarView.swift
@@ -137,7 +137,7 @@ struct MenuBarView: View {
 
     private func rowHeader(_ session: SessionEntry, numberHint: String?) -> some View {
         HStack {
-            Circle().fill(color(for: session.status)).frame(width: 10, height: 10)
+            Circle().fill(session.status.displayColor).frame(width: 10, height: 10)
             if isUnlinked(session) {
                 Image(systemName: "link.badge.plus")
                     .font(.caption2)
@@ -184,19 +184,6 @@ struct MenuBarView: View {
         if session.status == .done && session.doneNotified { return Color.gray.opacity(0.1) }
         if session.status == .idle { return Color.gray.opacity(0.1) }
         return Color.clear
-    }
-
-    private func color(for status: SessionStatus) -> Color {
-        switch status {
-        case .idle: return .gray
-        case .running: return .green
-        case .asking: return .orange
-        case .waitingInput: return .orange
-        case .done: return .gray
-        case .error: return .red
-        case .stale: return Color.gray.opacity(0.4)
-        case .deceased: return Color.gray.opacity(0.2)
-        }
     }
 
     private func relativeAge(_ timestamp: String) -> String {

--- a/ccfocus/ccfocus/SessionStatusColor.swift
+++ b/ccfocus/ccfocus/SessionStatusColor.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension SessionStatus {
+    var displayColor: Color {
+        switch self {
+        case .idle: return .gray
+        case .running: return .green
+        case .asking: return .orange
+        case .waitingInput: return .orange
+        case .done: return .gray
+        case .error: return .red
+        case .stale: return Color.gray.opacity(0.4)
+        case .deceased: return Color.gray.opacity(0.2)
+        }
+    }
+}

--- a/ccfocus/ccfocus/SettingsView.swift
+++ b/ccfocus/ccfocus/SettingsView.swift
@@ -15,6 +15,11 @@ struct SettingsView: View {
                 Spacer()
                 KeyboardShortcuts.Recorder(for: .toggleFocus)
             }
+            HStack {
+                Text("Cycle to next session:")
+                Spacer()
+                KeyboardShortcuts.Recorder(for: .cycleNext)
+            }
             Divider()
             Text("Accessibility")
                 .font(.headline)
@@ -34,7 +39,7 @@ struct SettingsView: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 420, height: 220, alignment: .topLeading)
+        .frame(width: 420, height: 260, alignment: .topLeading)
     }
 
     private func promptAndOpenAccessibilitySettings() {

--- a/ccfocus/ccfocusTests/GlobalCycleControllerTests.swift
+++ b/ccfocus/ccfocusTests/GlobalCycleControllerTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import ccfocus
+
+@MainActor
+final class GlobalCycleControllerTests: XCTestCase {
+    private final class FakeFocuser: TerminalFocusing {
+        var focused: [String] = []
+        func focus(terminalId: String) { focused.append(terminalId) }
+    }
+
+    private func seed(_ state: AppState, entries: [(sid: String, tid: String?, status: SessionStatus, ts: String)]) {
+        for (sid, tid, status, ts) in entries {
+            state.registry.sessions[sid] = SessionEntry(
+                sessionId: sid,
+                terminalId: tid,
+                cwd: "/tmp/\(sid)",
+                gitBranch: nil,
+                claudePid: nil,
+                claudeStartTime: nil,
+                claudeComm: nil,
+                status: status,
+                lastEventTs: ts,
+                lastMessage: nil,
+                deceasedReason: nil,
+                startedAt: ts
+            )
+        }
+    }
+
+    func testFirstPressFromNilAnchorSelectsHead() {
+        let state = AppState()
+        seed(state, entries: [
+            ("a", "t1", .idle, "2026-04-27T00:00:03Z"),
+            ("b", "t2", .idle, "2026-04-27T00:00:02Z"),
+            ("c", "t3", .idle, "2026-04-27T00:00:01Z")
+        ])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        let target = controller.cycleNext(state: state)
+        XCTAssertEqual(target?.sessionId, "a")
+        XCTAssertEqual(controller.anchorSessionId, "a")
+        XCTAssertEqual(focuser.focused, ["t1"])
+    }
+
+    func testAdvancesAndWraps() {
+        let state = AppState()
+        seed(state, entries: [
+            ("a", "t1", .idle, "2026-04-27T00:00:03Z"),
+            ("b", "t2", .idle, "2026-04-27T00:00:02Z"),
+            ("c", "t3", .idle, "2026-04-27T00:00:01Z")
+        ])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "a")
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "b")
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "c")
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "a")
+        XCTAssertEqual(focuser.focused, ["t1", "t2", "t3", "t1"])
+    }
+
+    func testAnchorMissingFromCandidatesRestartsFromHead() {
+        let state = AppState()
+        seed(state, entries: [
+            ("a", "t1", .idle, "2026-04-27T00:00:03Z"),
+            ("b", "t2", .idle, "2026-04-27T00:00:02Z")
+        ])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        _ = controller.cycleNext(state: state) // anchor = a
+        state.registry.sessions["a"]?.status = .deceased
+        let target = controller.cycleNext(state: state)
+        XCTAssertEqual(target?.sessionId, "b")
+        XCTAssertEqual(controller.anchorSessionId, "b")
+    }
+
+    func testEmptyCandidatesReturnsNilAndResetsAnchor() {
+        let state = AppState()
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        XCTAssertNil(controller.cycleNext(state: state))
+        XCTAssertNil(controller.anchorSessionId)
+        XCTAssertTrue(focuser.focused.isEmpty)
+    }
+
+    func testSkipsDeceasedAndUnlinkedSessions() {
+        let state = AppState()
+        seed(state, entries: [
+            ("a", nil, .idle, "2026-04-27T00:00:03Z"),
+            ("b", "t2", .deceased, "2026-04-27T00:00:02Z"),
+            ("c", "t3", .idle, "2026-04-27T00:00:01Z")
+        ])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        let target = controller.cycleNext(state: state)
+        XCTAssertEqual(target?.sessionId, "c")
+        XCTAssertEqual(focuser.focused, ["t3"])
+    }
+
+    func testSingleCandidateRecyclesItself() {
+        let state = AppState()
+        seed(state, entries: [
+            ("a", "t1", .idle, "2026-04-27T00:00:01Z")
+        ])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "a")
+        XCTAssertEqual(controller.cycleNext(state: state)?.sessionId, "a")
+        XCTAssertEqual(focuser.focused, ["t1", "t1"])
+    }
+
+    func testResetClearsAnchor() {
+        let state = AppState()
+        seed(state, entries: [("a", "t1", .idle, "2026-04-27T00:00:01Z")])
+        let focuser = FakeFocuser()
+        let controller = GlobalCycleController(focuser: focuser)
+        _ = controller.cycleNext(state: state)
+        controller.reset()
+        XCTAssertNil(controller.anchorSessionId)
+    }
+}


### PR DESCRIPTION
## Summary
- Global keyboard shortcut to cycle to the next live Claude Code session, focusing the Ghostty pane immediately without opening the popover.
- A 1.0s center-screen HUD shows the project name with a colored status dot. Project name uses 44pt SemiBold; the HUD lives on a `.statusBar` level NSPanel that ignores mouse events and rides on the screen the cursor is on.
- Settings exposes a Recorder for the new `cycleNext` shortcut (default unset). The popover Tab/Shift+Tab cycle is unchanged and uses an anchor independent from this Global Cycle.

## Test plan
- [x] xcodebuild test passes (102 tests, 7 new in GlobalCycleControllerTests)
- [x] xcodebuild build succeeds (Debug)
- [ ] Assign a shortcut in Settings → press from another app → Ghostty focuses the next session and HUD shows project + dot for ~1s
- [ ] Rapid presses cycle through sessions and reset the HUD timer; HUD content updates without flicker
- [ ] No candidates → no HUD, no Ghostty switch
- [ ] Popover open + Global Cycle press → popover stays open, Ghostty focuses, HUD shows
- [ ] Multi-display: HUD appears on the screen the mouse cursor is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)