### PR TITLE
chore: bump renovate minimumReleaseAge to 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "before 9am on monday"
   ],
   "timezone": "Asia/Tokyo",
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "automerge": true,
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
## What
Renovateの `minimumReleaseAge` を 3 days → 7 days に引き上げる。