### PR TITLE
feat: add launch-at-login toggle in settings

### DIFF
--- a/ccfocus/ccfocus/CcfocusApp.swift
+++ b/ccfocus/ccfocus/CcfocusApp.swift
@@ -1,5 +1,4 @@
 import AppKit
-import ServiceManagement
 import SwiftUI
 
 @main
@@ -31,7 +30,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var panelUserOwned: Bool = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        registerLoginItemIfNeeded()
         state.bootstrap()
         state.onOpenPopover = { [weak self] in self?.showPanelUnfocused(automatic: true) }
         state.onClosePopover = { [weak self] in
@@ -281,15 +279,5 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panel.close()
         panelUserOwned = false
         removeClickOutsideMonitor()
-    }
-
-    private func registerLoginItemIfNeeded() {
-        let key = "loginItemRegistered"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        let service = SMAppService.mainApp
-        if service.status != .enabled {
-            try? service.register()
-        }
-        UserDefaults.standard.set(true, forKey: key)
     }
 }

--- a/ccfocus/ccfocus/LoginItemViewState.swift
+++ b/ccfocus/ccfocus/LoginItemViewState.swift
@@ -1,0 +1,28 @@
+import ServiceManagement
+
+struct LoginItemViewState: Equatable {
+    let isEnabled: Bool
+    let needsApproval: Bool
+    let approvalText: String?
+
+    init(status: SMAppService.Status) {
+        switch status {
+        case .enabled:
+            isEnabled = true
+            needsApproval = false
+            approvalText = nil
+        case .requiresApproval:
+            isEnabled = true
+            needsApproval = true
+            approvalText = "Approval required — enable ccfocus in System Settings › Login Items"
+        case .notRegistered, .notFound:
+            isEnabled = false
+            needsApproval = false
+            approvalText = nil
+        @unknown default:
+            isEnabled = false
+            needsApproval = false
+            approvalText = nil
+        }
+    }
+}

--- a/ccfocus/ccfocus/SettingsView.swift
+++ b/ccfocus/ccfocus/SettingsView.swift
@@ -1,10 +1,12 @@
 import ApplicationServices
 import AppKit
 import KeyboardShortcuts
+import ServiceManagement
 import SwiftUI
 
 struct SettingsView: View {
     @State private var isAccessibilityTrusted: Bool = AXIsProcessTrusted()
+    @State private var loginItem = LoginItemViewState(status: SMAppService.mainApp.status)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -19,6 +21,25 @@ struct SettingsView: View {
                 Text("Cycle to next session:")
                 Spacer()
                 KeyboardShortcuts.Recorder(for: .cycleNext)
+            }
+            Divider()
+            Text("Launch at Login")
+                .font(.headline)
+            Toggle("Open ccfocus at login", isOn: Binding(
+                get: { loginItem.isEnabled },
+                set: { setLoginItem(enabled: $0) }
+            ))
+            if loginItem.needsApproval {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(loginItem.approvalText ?? "")
+                        .font(.caption)
+                    Spacer()
+                    Button("Open Login Items") {
+                        SMAppService.openSystemSettingsLoginItems()
+                    }
+                }
             }
             Divider()
             Text("Accessibility")
@@ -39,7 +60,21 @@ struct SettingsView: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 420, height: 260, alignment: .topLeading)
+        .frame(width: 420, height: 320, alignment: .topLeading)
+    }
+
+    private func setLoginItem(enabled: Bool) {
+        let service = SMAppService.mainApp
+        do {
+            if enabled {
+                try service.register()
+            } else {
+                try service.unregister()
+            }
+        } catch {
+            // 実際の状態は status から読み直して反映する
+        }
+        loginItem = LoginItemViewState(status: service.status)
     }
 
     private func promptAndOpenAccessibilitySettings() {

--- a/ccfocus/ccfocusTests/LoginItemViewStateTests.swift
+++ b/ccfocus/ccfocusTests/LoginItemViewStateTests.swift
@@ -1,0 +1,32 @@
+import ServiceManagement
+import XCTest
+@testable import ccfocus
+
+final class LoginItemViewStateTests: XCTestCase {
+    func testEnabledStatusTurnsToggleOnWithoutApproval() {
+        let state = LoginItemViewState(status: .enabled)
+        XCTAssertTrue(state.isEnabled)
+        XCTAssertFalse(state.needsApproval)
+        XCTAssertNil(state.approvalText)
+    }
+
+    func testNotRegisteredStatusTurnsToggleOff() {
+        let state = LoginItemViewState(status: .notRegistered)
+        XCTAssertFalse(state.isEnabled)
+        XCTAssertFalse(state.needsApproval)
+        XCTAssertNil(state.approvalText)
+    }
+
+    func testNotFoundStatusTurnsToggleOff() {
+        let state = LoginItemViewState(status: .notFound)
+        XCTAssertFalse(state.isEnabled)
+        XCTAssertFalse(state.needsApproval)
+    }
+
+    func testRequiresApprovalKeepsToggleOnAndShowsApprovalText() {
+        let state = LoginItemViewState(status: .requiresApproval)
+        XCTAssertTrue(state.isEnabled)
+        XCTAssertTrue(state.needsApproval)
+        XCTAssertNotNil(state.approvalText)
+    }
+}


### PR DESCRIPTION
## Summary

Add a "Launch at Login" toggle to the Settings window so users can enable/disable login-item registration directly, instead of the previous silent auto-registration on first launch.

- New `LoginItemViewState` pure-logic type derives toggle/approval UI state from `SMAppService.mainApp.status` (the single source of truth); unit-tested
- `SettingsView` gains a "Launch at Login" section: a toggle that calls `register()`/`unregister()`, plus an approval affordance shown only when macOS returns `.requiresApproval` (mirrors the neighboring Accessibility section)
- Remove the first-launch auto-register path and the `loginItemRegistered` UserDefaults flag from `CcfocusApp`

## Test

- `xcodebuild test` (ccfocusTests) — all green, including new `LoginItemViewStateTests`
- Full `xcodebuild build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)